### PR TITLE
feat(security): add dangerous rm command protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tmp/
 
 # Private development planning (OPSEC - keep internal strategies private)
 todos/
+tasks/
 
 # Repository-specific Claude Code configuration (gitignored for OPSEC)
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ _Naming scheme derived from Solo Leveling because I decided why not ([Image Sour
 ### What Igris Provides
 
 - **Hardware Verification Enforcement** - YubiKey tap OR Touch ID via 1Password CLI
-- **Command-Specific Audio Alerts** - Modular voice notifications for each git operation
+- **Git/GitHub Protection** - All network operations require hardware verification
+- **Dangerous Command Protection** - Block `rm -rf ~/` and similar catastrophic commands
+- **Command-Specific Audio Alerts** - Modular voice notifications for each operation
 - **Defense-in-Depth Architecture** with multiple enforcement layers preventing bypass
+- **Environment-Aware** - Main machine protection, VM pass-through for sandboxed work
 - **Flexible Authentication** - Use YubiKey (most secure) or Touch ID (convenient alternative)
 - **Cryptographic Verification** via HMAC-SHA1 challenge-response with touch requirement
 - **Bypass Detection Alerts** - Audio warnings when enforcement is disabled
@@ -28,10 +31,13 @@ _Naming scheme derived from Solo Leveling because I decided why not ([Image Sour
 - `git push`, `git pull`, `git fetch`, `git clone`
 - `git remote add/update/set-url`, `git submodule update --remote`
 - `gh pr create/merge`, `gh release create`, `gh repo clone`, `gh workflow run`
+- `rm -rf /`, `rm -rf ~`, `rm -rf /Users/*` (with `--dangerous-commands` flag)
 
 **Pass-Through Operations (No Tap):**
 - `git commit`, `git status`, `git log`, `git diff`
 - All read-only and local operations
+- `rm` commands not targeting protected paths
+- All commands in VM environments (sandbox mode)
 
 <details>
 <summary><strong>🏗️ Architecture</strong></summary>
@@ -626,20 +632,24 @@ igris/
 │   ├── yubikey-verify.sh            # Core verification logic + audio
 │   ├── git-yubikey-wrapper.sh       # Git command wrapper
 │   ├── gh-yubikey-wrapper.sh        # GitHub CLI wrapper
-│   ├── hardware-git-setup.sh         # Management CLI
-│   └── yubikey-configure-otp.sh     # YubiKey OTP configuration
+│   ├── rm-yubikey-wrapper.sh        # Dangerous rm command wrapper
+│   ├── hardware-git-setup.sh        # Management CLI
+│   ├── yubikey-configure-otp.sh     # YubiKey OTP configuration
+│   └── test-rm-protection.sh        # Test suite for rm protection
 ├── hooks/
 │   └── git-hooks/
 │       └── pre-push                  # Pre-push hook template
 ├── configs/
-│   ├── yubikey-enforcement.yml       # Main configuration file
-│   └── audio-alerts.yml              # Audio alert mappings
+│   ├── yubikey-enforcement.yml       # Main configuration file (includes dangerous_commands)
+│   └── audio-alerts.yml              # Audio alert mappings (includes dangerous commands)
 ├── assets/
 │   └── audio/
 │       ├── README.md                 # Audio setup guide
-│       ├── prefix-*.wav              # Modular prefix clip
+│       ├── prefix-*.wav              # Modular prefix clips
 │       ├── action-*.wav              # Modular action clips
-│       └── bypass-detected.wav       # Security alert sound
+│       ├── bypass-detected.wav       # Security alert sound
+│       └── dangerous/                # Dangerous command audio files
+│           └── README.md             # Voice generation guide
 └── README.md                         # This file
 ```
 

--- a/assets/audio/dangerous/README.md
+++ b/assets/audio/dangerous/README.md
@@ -1,0 +1,48 @@
+# Dangerous Command Audio Files
+
+Audio clips for dangerous shell command protection (rm -rf, etc.).
+
+## Required Files
+
+| File | Phrase | Tone | Duration |
+|------|--------|------|----------|
+| `prefix-dangerous-operation.wav` | "YubiKey tap required for dangerous operation" | Serious, warning (firm but not panic) | ~2s |
+| `action-rm.wav` | "remove" | Clear, final | ~0.5s |
+
+## Generation Guide
+
+Use ElevenLabs with these settings:
+- **Voice**: Albedo v2 (or your preferred voice)
+- **Stability**: 0.5-0.6 (consistent but with some variation)
+- **Similarity**: 0.75 (natural)
+- **Style**: 0.2-0.3 (subtle expression)
+
+### Prompts
+
+**prefix-dangerous-operation.wav**:
+```
+YubiKey tap required for dangerous operation
+```
+- Tone: Authoritative warning
+- Pacing: Measured, clear
+- Not panicked, but serious
+
+**action-rm.wav**:
+```
+remove
+```
+- Tone: Clear, final
+- Pacing: Normal
+- Conveys finality of the action
+
+## Future Audio Files
+
+When additional commands are added:
+- `action-sudo.wav` - "sudo"
+- `action-chmod.wav` - "chmod"
+
+## Fallback
+
+If audio files are missing, the system falls back to:
+1. `prefix_sound_security` from global config
+2. System sound: Sosumi (serious alert)

--- a/configs/audio-alerts.yml
+++ b/configs/audio-alerts.yml
@@ -170,3 +170,37 @@ onepassword:
 #
 # Security alerts:
 #   bypass-detected.wav: "Warning: YubiKey enforcement has been bypassed"
+
+# Dangerous shell command protection
+# Audio alerts for destructive operations (rm -rf, etc.)
+dangerous_commands:
+  enabled: true
+  prefix_sound: assets/audio/dangerous/prefix-dangerous-operation.wav  # "YubiKey tap required for dangerous operation"
+  category: security  # Uses prefix_sound_security tone
+
+  rm:
+    enabled: true
+    modular_audio: assets/audio/dangerous/action-rm.wav  # Just "remove"
+    description: "Dangerous rm operation (rm -rf targeting protected paths)"
+
+  # Future commands (uncomment when adding support)
+  # sudo:
+  #   enabled: false
+  #   modular_audio: assets/audio/dangerous/action-sudo.wav  # Just "sudo"
+  #   description: "Privileged command execution"
+  #
+  # chmod:
+  #   enabled: false
+  #   modular_audio: assets/audio/dangerous/action-chmod.wav  # Just "chmod"
+  #   description: "Dangerous chmod operation"
+
+# Voice clip generation guide for dangerous commands:
+# Using ElevenLabs with authoritative/warning tone:
+#
+# Prefix:
+#   prefix-dangerous-operation.wav: "YubiKey tap required for dangerous operation"
+#     Tone: Serious, warning (not urgent panic, but firm)
+#
+# Actions:
+#   action-rm.wav: "remove"
+#     Tone: Clear, final (this is destructive)

--- a/configs/yubikey-enforcement.yml
+++ b/configs/yubikey-enforcement.yml
@@ -87,6 +87,43 @@ integration:
     - $GIT_ROOT/internal/repos/EchoLink-Reborn
     - $GIT_ROOT/internal/repos/carian-constellation
 
+# Dangerous Shell Command Protection
+# Extends YubiKey verification to destructive shell commands (rm -rf, etc.)
+dangerous_commands:
+  enabled: true
+  environment: main_only       # main_only | all (VM passes through)
+  # main_only: Only enforce on main machine (/Users/fweir)
+  # all: Enforce everywhere (not recommended - VM is sandbox)
+
+  rm:
+    enabled: true
+    # Dangerous flag patterns that trigger verification
+    dangerous_patterns:
+      - "-rf"                  # rm -rf anything
+      - "-r.*-f"               # rm -r with -f anywhere
+      - "-fr"                  # rm -fr variant
+      - "-f.*-r"               # rm -f with -r anywhere
+    # Protected paths - operations targeting these require verification
+    protected_paths:
+      - "/"                    # root
+      - "~"                    # home (literal tilde)
+      - "$HOME"                # home expanded
+      - "/Users"               # all users
+      - "/System"              # macOS system
+      - "/usr"                 # unix system
+      - "/opt"                 # homebrew root
+      - "/Applications"        # macOS apps
+      - "/Library"             # system library
+    protection_level: required # required | warn_only
+
+  # Future: Additional commands can be added here
+  # sudo:
+  #   enabled: false
+  #   dangerous_subcommands: [rm, chmod, chown, dd, mkfs]
+  # chmod:
+  #   enabled: false
+  #   dangerous_patterns: ["777", "-R.*777", "000"]
+
 devices:
   # Multiple YubiKeys can be registered for redundancy
   allowed_serials:

--- a/configs/yubikey-enforcement.yml
+++ b/configs/yubikey-enforcement.yml
@@ -5,7 +5,7 @@
 enforcement:
   enabled: true                # Master switch for YubiKey enforcement
   require_tap: true            # Require physical tap (vs just presence)
-  timeout_seconds: 10          # How long to wait for tap
+  timeout_seconds: 30          # How long to wait for tap
   retry_attempts: 3            # Failed attempts before lockout warning
 
 verification:

--- a/scripts/hardware-git-setup.sh
+++ b/scripts/hardware-git-setup.sh
@@ -11,6 +11,7 @@ TOMB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VERIFY_SCRIPT="${TOMB_DIR}/scripts/yubikey-verify.sh"
 GIT_WRAPPER="${TOMB_DIR}/scripts/git-yubikey-wrapper.sh"
 GH_WRAPPER="${TOMB_DIR}/scripts/gh-yubikey-wrapper.sh"
+RM_WRAPPER="${TOMB_DIR}/scripts/rm-yubikey-wrapper.sh"
 PRE_PUSH_HOOK="${TOMB_DIR}/hooks/git-hooks/pre-push"
 CONFIG_FILE="${TOMB_DIR}/configs/yubikey-enforcement.yml"
 BACKUP_DIR="${HOME}/.tomb-yubikey-backup"
@@ -64,17 +65,19 @@ COMMANDS:
     test        Test YubiKey verification
 
 OPTIONS:
-    --global        Apply to user shell config (default)
-    --all-repos     Install hooks in all workspace repos
-    --repo <path>   Target specific repository
-    --non-interactive  Skip prompts and use defaults
+    --global             Apply to user shell config (default)
+    --all-repos          Install hooks in all workspace repos
+    --repo <path>        Target specific repository
+    --non-interactive    Skip prompts and use defaults
+    --dangerous-commands Install rm wrapper for dangerous command protection
 
 EXAMPLES:
-    $(basename "$0") setup              # Interactive setup with prompts
-    $(basename "$0") setup --all-repos  # Install + add hooks to all repos
-    $(basename "$0") status             # Check current status
-    $(basename "$0") disable            # Temporarily disable (keep config)
-    $(basename "$0") test               # Test YubiKey verification
+    $(basename "$0") setup                        # Interactive setup with prompts
+    $(basename "$0") setup --all-repos            # Install + add hooks to all repos
+    $(basename "$0") setup --dangerous-commands   # Also protect dangerous rm commands
+    $(basename "$0") status                       # Check current status
+    $(basename "$0") disable                      # Temporarily disable (keep config)
+    $(basename "$0") test                         # Test YubiKey verification
 
 EOF
 }
@@ -217,6 +220,7 @@ detect_shell_config() {
 cmd_setup() {
     local interactive=true
     local install_all_repos=false
+    local install_dangerous_commands=false
 
     # Parse options
     while [[ $# -gt 0 ]]; do
@@ -227,6 +231,10 @@ cmd_setup() {
                 ;;
             --all-repos)
                 install_all_repos=true
+                shift
+                ;;
+            --dangerous-commands)
+                install_dangerous_commands=true
                 shift
                 ;;
             *)
@@ -328,6 +336,19 @@ EOF
         print_success "Shell wrappers installed"
     fi
 
+    # Install dangerous commands wrapper (rm) if requested
+    if [ "$install_dangerous_commands" = true ]; then
+        install_rm_wrapper "$shell_config"
+    elif [ "$interactive" = true ]; then
+        echo ""
+        print_info "Dangerous command protection (rm -rf) is available."
+        if confirm_action "Also install protection for dangerous rm commands?" "no"; then
+            install_rm_wrapper "$shell_config"
+        else
+            print_info "Skipped rm protection (you can add later with --dangerous-commands)"
+        fi
+    fi
+
     # Setup git global hooks
     print_info "Setting up git global hooks..."
 
@@ -427,6 +448,34 @@ EOF
     print_info "To check status anytime: $(basename "$0") status"
     print_info "To remove completely: $(basename "$0") remove"
     echo ""
+}
+
+# Install rm wrapper for dangerous command protection
+install_rm_wrapper() {
+    local shell_config="$1"
+
+    print_info "Installing dangerous rm command protection..."
+
+    # Check if already installed
+    if grep -q "Dangerous rm Protection" "$shell_config" 2>/dev/null; then
+        print_warning "rm wrapper already installed in $shell_config"
+        return 0
+    fi
+
+    cat >> "$shell_config" << EOF
+
+# Dangerous rm Protection (managed by igris)
+# Requires YubiKey tap for dangerous rm operations (rm -rf /, rm -rf ~, etc.)
+# Only enforces on main machine - VM environments pass through
+export TOMB_DANGEROUS_ENABLED=true
+
+rm() {
+    "$RM_WRAPPER" "\$@"
+}
+
+EOF
+
+    print_success "rm wrapper installed - dangerous operations require YubiKey"
 }
 
 # Install hooks in workspace repos
@@ -561,6 +610,13 @@ cmd_status() {
         echo -e "Wrappers:    ${GREEN}✅ Installed${NC} (git, gh)"
     else
         echo -e "Wrappers:    ${RED}❌ Not installed${NC}"
+    fi
+
+    # Check rm wrapper
+    if grep -q "Dangerous rm Protection" "$shell_config" 2>/dev/null; then
+        echo -e "rm protect:  ${GREEN}✅ Installed${NC} (dangerous rm requires YubiKey)"
+    else
+        echo -e "rm protect:  ${YELLOW}⚠️  Not installed${NC} (add with --dangerous-commands)"
     fi
 
     # Check hooks
@@ -699,9 +755,17 @@ cmd_remove() {
         # Also remove the compdef lines if they exist
         sed -i.bak '/compdef _git git=git/d' "$shell_config"
         sed -i.bak '/compdef _gh gh=gh/d' "$shell_config"
-        print_success "Removed wrappers from shell config"
+        print_success "Removed git/gh wrappers from shell config"
     else
-        print_info "No wrappers found in shell config"
+        print_info "No git/gh wrappers found in shell config"
+    fi
+
+    # Remove rm wrapper
+    if grep -q "Dangerous rm Protection" "$shell_config" 2>/dev/null; then
+        sed -i.bak '/# Dangerous rm Protection/,/^$/d' "$shell_config"
+        print_success "Removed rm wrapper from shell config"
+    else
+        print_info "No rm wrapper found in shell config"
     fi
 
     # Remove git hooks from template

--- a/scripts/hardware-verify.sh
+++ b/scripts/hardware-verify.sh
@@ -13,6 +13,23 @@ TOUCHID_VERIFY="${TOMB_DIR}/scripts/touchid-verify.sh"
 CONFIG_FILE="${TOMB_DIR}/configs/yubikey-enforcement.yml"
 LOG_FILE="${HOME}/.tomb-yubikey-verifications.log"
 
+# Parse config for verification method and Touch ID settings
+# Default to yubikey-only mode (most secure)
+VERIFICATION_METHOD="${TOMB_VERIFICATION_METHOD:-}"
+TOUCHID_ENABLED="${TOMB_TOUCHID_ENABLED:-}"
+
+# Read from config file if not set via environment
+if [ -z "$VERIFICATION_METHOD" ] && [ -f "$CONFIG_FILE" ]; then
+    VERIFICATION_METHOD=$(grep -E "^\s*method:" "$CONFIG_FILE" | head -1 | awk '{print $2}' | tr -d '\r')
+fi
+if [ -z "$TOUCHID_ENABLED" ] && [ -f "$CONFIG_FILE" ]; then
+    TOUCHID_ENABLED=$(grep -E "^\s+enabled:" "$CONFIG_FILE" | head -1 | awk '{print $2}' | tr -d '\r')
+fi
+
+# Defaults: yubikey-only mode, Touch ID disabled
+VERIFICATION_METHOD="${VERIFICATION_METHOD:-yubikey}"
+TOUCHID_ENABLED="${TOUCHID_ENABLED:-false}"
+
 # Use Homebrew ykman explicitly to avoid broken Python installations
 if [ -x "/opt/homebrew/bin/ykman" ]; then
     YKMAN_BIN="/opt/homebrew/bin/ykman"
@@ -75,6 +92,28 @@ check_touchid_available() {
     command -v op &> /dev/null && op account list &>/dev/null 2>&1
 }
 
+# Check if Touch ID fallback is allowed based on config
+is_touchid_fallback_allowed() {
+    # Respect verification method setting
+    case "$VERIFICATION_METHOD" in
+        yubikey)
+            # YubiKey-only mode: no Touch ID fallback
+            return 1
+            ;;
+        touchid)
+            # Touch ID only mode: always allow (but YubiKey skipped above)
+            return 0
+            ;;
+        auto|*)
+            # Auto mode: check if Touch ID is explicitly enabled
+            if [ "$TOUCHID_ENABLED" = "true" ]; then
+                return 0
+            fi
+            return 1
+            ;;
+    esac
+}
+
 # Main verification flow
 main() {
     # Check if enforcement is enabled
@@ -83,24 +122,32 @@ main() {
     fi
 
     print_info "Hardware verification required for: ${OPERATION}"
+    print_info "Verification mode: ${VERIFICATION_METHOD} (Touch ID fallback: ${TOUCHID_ENABLED})"
     echo "" >&2
 
-    # Try verification methods in priority order
+    # Try verification methods based on configuration
 
     # 1. YubiKey (most secure - hardware token with cryptographic verification)
-    # Skip YubiKey if TOMB_TOUCHID_ONLY is set (for testing)
-    if [ "${TOMB_TOUCHID_ONLY:-false}" = "false" ] && check_yubikey_available; then
+    # Skip YubiKey if TOMB_TOUCHID_ONLY is set (for testing) or method is touchid-only
+    if [ "${TOMB_TOUCHID_ONLY:-false}" = "false" ] && [ "$VERIFICATION_METHOD" != "touchid" ] && check_yubikey_available; then
         print_info "Attempting YubiKey verification (most secure)..."
         if "$YUBIKEY_VERIFY" "$OPERATION"; then
             exit 0
         fi
         echo "" >&2
-        print_warning "YubiKey verification failed, trying alternative methods..."
+
+        # Only mention fallback if Touch ID is actually allowed
+        if is_touchid_fallback_allowed; then
+            print_warning "YubiKey verification failed, trying Touch ID fallback..."
+        else
+            print_warning "YubiKey verification failed (Touch ID fallback disabled)"
+        fi
         echo "" >&2
     fi
 
     # 2. Touch ID (secure - biometric with hardware-backed Secure Enclave)
-    if check_touchid_available; then
+    # Only attempt if allowed by configuration
+    if is_touchid_fallback_allowed && check_touchid_available; then
         print_info "Attempting Touch ID verification..."
         if "$TOUCHID_VERIFY" "$OPERATION"; then
             exit 0
@@ -111,12 +158,16 @@ main() {
     fi
 
     # All methods failed
-    print_error "All hardware verification methods failed"
+    print_error "Hardware verification failed"
     log_verification "FAILURE" "all_methods"
     echo "" >&2
     print_info "Recovery options:" >&2
     echo "  1. Connect your YubiKey and try again" >&2
-    echo "  2. Ensure 1Password CLI is signed in: op signin" >&2
+    if [ "$VERIFICATION_METHOD" = "yubikey" ]; then
+        echo "  2. Enable Touch ID fallback: set touchid.enabled: true in config" >&2
+    else
+        echo "  2. Ensure 1Password CLI is signed in: op signin" >&2
+    fi
     echo "  3. Temporarily disable: export TOMB_YUBIKEY_ENABLED=false" >&2
     echo "  4. Check status: ${TOMB_DIR}/scripts/hardware-git-setup.sh status" >&2
 

--- a/scripts/rm-yubikey-wrapper.sh
+++ b/scripts/rm-yubikey-wrapper.sh
@@ -37,13 +37,20 @@ PROTECTED_PATHS=(
 )
 
 # Environment detection (main machine vs VM)
+# Uses portable detection without hardcoded usernames
 detect_environment() {
-    if [[ "$HOME" == /Users/fweir ]]; then
-        echo "main"
-    elif [[ "$HOME" == /Users/fweirvm ]] || [[ "${PWD:-}" == /Volumes/* ]]; then
+    # VM indicators:
+    # 1. Working directory is on a mounted volume (shared from another machine)
+    # 2. Username ends with "vm" (convention for VM user accounts)
+    # 3. TOMB_ENVIRONMENT explicitly set
+    if [[ -n "${TOMB_ENVIRONMENT:-}" ]]; then
+        echo "$TOMB_ENVIRONMENT"
+    elif [[ "${PWD:-}" == /Volumes/* ]]; then
+        echo "vm"
+    elif [[ "$(whoami)" == *vm ]]; then
         echo "vm"
     else
-        echo "unknown"
+        echo "main"
     fi
 }
 
@@ -71,7 +78,7 @@ targets_protected_path() {
         # Exact match or starts with protected path
         if [[ "$args" == *"$path"* ]] || [[ "$args" == *"$path/"* ]]; then
             # Exclude legitimate subdirectories deep within protected areas
-            # e.g., /Users/fweir/git/project is OK, /Users alone is not
+            # e.g., $HOME/git/project is OK, /Users alone is not
             local safe_depth=0
             for arg in $args; do
                 # Skip flags
@@ -81,7 +88,7 @@ targets_protected_path() {
                 local depth=$(echo "$arg" | tr '/' '\n' | wc -l)
 
                 # If targeting root-level protected paths (depth <= 3), it's dangerous
-                # /Users = 2, /Users/fweir = 3, /Users/fweir/git = 4 (OK)
+                # /Users = 2, $HOME = 3, $HOME/git = 4 (OK)
                 case "$path" in
                     "/"|"/Users"|"/System"|"/usr"|"/opt"|"/Applications"|"/Library"|"/bin"|"/sbin"|"/var"|"/private")
                         if [[ "$arg" == "$path" ]] || [[ "$arg" == "$path/" ]]; then

--- a/scripts/rm-yubikey-wrapper.sh
+++ b/scripts/rm-yubikey-wrapper.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# rm Hardware Verification Wrapper
+# Intercepts rm commands and requires hardware verification for dangerous operations
+# Part of Igris security enforcement system
+#
+# Protects against catastrophic rm commands like:
+#   rm -rf ~/
+#   rm -rf /
+#   rm -rf /Users/*
+#
+# Only enforces on main machine - VM environments pass through
+
+set -euo pipefail
+
+# Get the actual rm binary (not this wrapper)
+RM_BINARY="/bin/rm"
+TOMB_DIR="${TOMB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+VERIFY_SCRIPT="${TOMB_DIR}/scripts/hardware-verify.sh"
+LOG_FILE="${HOME}/.tomb-yubikey-verifications.log"
+
+# Protected paths - operations targeting these require verification
+# Note: ~ is checked both literally and expanded
+PROTECTED_PATHS=(
+    "/"
+    "$HOME"
+    "/Users"
+    "/System"
+    "/usr"
+    "/opt"
+    "/Applications"
+    "/Library"
+    "/bin"
+    "/sbin"
+    "/var"
+    "/private"
+)
+
+# Environment detection (main machine vs VM)
+detect_environment() {
+    if [[ "$HOME" == /Users/fweir ]]; then
+        echo "main"
+    elif [[ "$HOME" == /Users/fweirvm ]] || [[ "${PWD:-}" == /Volumes/* ]]; then
+        echo "vm"
+    else
+        echo "unknown"
+    fi
+}
+
+# Check if arguments contain dangerous flag patterns
+has_dangerous_flags() {
+    local args="$*"
+
+    # Dangerous combinations: recursive + force
+    # -rf, -fr, -r -f, -f -r (in any order)
+    [[ "$args" =~ -rf ]] || [[ "$args" =~ -fr ]] || \
+    [[ "$args" =~ -r[[:space:]]+-f ]] || [[ "$args" =~ -f[[:space:]]+-r ]] || \
+    [[ "$args" =~ -r.*-f ]] || [[ "$args" =~ -f.*-r ]]
+}
+
+# Check if arguments target protected paths
+targets_protected_path() {
+    local args="$*"
+
+    # Check for literal tilde
+    if [[ "$args" == *"~"* ]]; then
+        return 0
+    fi
+
+    for path in "${PROTECTED_PATHS[@]}"; do
+        # Exact match or starts with protected path
+        if [[ "$args" == *"$path"* ]] || [[ "$args" == *"$path/"* ]]; then
+            # Exclude legitimate subdirectories deep within protected areas
+            # e.g., /Users/fweir/git/project is OK, /Users alone is not
+            local safe_depth=0
+            for arg in $args; do
+                # Skip flags
+                [[ "$arg" == -* ]] && continue
+
+                # Count path depth
+                local depth=$(echo "$arg" | tr '/' '\n' | wc -l)
+
+                # If targeting root-level protected paths (depth <= 3), it's dangerous
+                # /Users = 2, /Users/fweir = 3, /Users/fweir/git = 4 (OK)
+                case "$path" in
+                    "/"|"/Users"|"/System"|"/usr"|"/opt"|"/Applications"|"/Library"|"/bin"|"/sbin"|"/var"|"/private")
+                        if [[ "$arg" == "$path" ]] || [[ "$arg" == "$path/" ]]; then
+                            return 0  # Dangerous: targeting protected path directly
+                        fi
+                        ;;
+                    "$HOME")
+                        if [[ "$arg" == "$HOME" ]] || [[ "$arg" == "$HOME/" ]]; then
+                            return 0  # Dangerous: targeting home directory
+                        fi
+                        ;;
+                esac
+            done
+        fi
+    done
+
+    return 1  # Safe path
+}
+
+# Log dangerous operation attempt
+log_operation() {
+    local status="$1"
+    local operation="$2"
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S+0000")
+
+    echo "$timestamp [$status] $operation" >> "$LOG_FILE"
+}
+
+# Main wrapper logic
+main() {
+    # If no arguments, pass through
+    if [ $# -eq 0 ]; then
+        exec "$RM_BINARY"
+    fi
+
+    # Check if dangerous command protection is enabled
+    if [[ "${TOMB_DANGEROUS_ENABLED:-true}" != "true" ]]; then
+        exec "$RM_BINARY" "$@"
+    fi
+
+    # Environment detection - VM passes through
+    local env
+    env=$(detect_environment)
+
+    if [[ "$env" != "main" ]]; then
+        # VM environment - pass through without verification
+        exec "$RM_BINARY" "$@"
+    fi
+
+    # Check if operation is dangerous (flags + protected path)
+    if has_dangerous_flags "$@" && targets_protected_path "$@"; then
+        echo "" >&2
+        echo "============================================" >&2
+        echo "DANGEROUS OPERATION DETECTED" >&2
+        echo "============================================" >&2
+        echo "Command: rm $*" >&2
+        echo "" >&2
+        echo "This operation requires YubiKey verification." >&2
+        echo "Please tap your YubiKey when it blinks." >&2
+        echo "============================================" >&2
+        echo "" >&2
+
+        # Dry run mode for testing
+        if [[ "${TOMB_DRY_RUN:-false}" == "true" ]]; then
+            echo "[DRY RUN] Would require YubiKey verification" >&2
+            log_operation "DRY_RUN" "rm $*"
+            exit 0
+        fi
+
+        # Verify hardware before proceeding
+        if [ -x "$VERIFY_SCRIPT" ]; then
+            if ! "$VERIFY_SCRIPT" "rm: dangerous delete"; then
+                echo "" >&2
+                echo "Operation blocked - YubiKey verification failed" >&2
+                log_operation "BLOCKED" "rm $*"
+                exit 1
+            fi
+
+            echo "" >&2
+            echo "YubiKey verified - proceeding with rm" >&2
+            log_operation "VERIFIED" "rm $*"
+        else
+            echo "Warning: Hardware verification script not found at: $VERIFY_SCRIPT" >&2
+            echo "Proceeding without verification - this is a security risk!" >&2
+            log_operation "NO_VERIFY_SCRIPT" "rm $*"
+        fi
+    fi
+
+    # Safe operation or verification passed - execute
+    exec "$RM_BINARY" "$@"
+}
+
+main "$@"

--- a/scripts/rm-yubikey-wrapper.sh
+++ b/scripts/rm-yubikey-wrapper.sh
@@ -89,8 +89,18 @@ targets_protected_path() {
                         fi
                         ;;
                     "$HOME")
+                        # Protect home directory and its direct children
+                        # $HOME = dangerous, $HOME/foo = dangerous, $HOME/foo/bar = safe
                         if [[ "$arg" == "$HOME" ]] || [[ "$arg" == "$HOME/" ]]; then
-                            return 0  # Dangerous: targeting home directory
+                            return 0  # Dangerous: targeting home directory directly
+                        fi
+                        # Check if targeting direct child of home (e.g., ~/Documents, ~/git)
+                        if [[ "$arg" == "$HOME/"* ]]; then
+                            # Count slashes after $HOME - if only one more, it's a direct child
+                            local after_home="${arg#$HOME/}"
+                            if [[ "$after_home" != *"/"* ]]; then
+                                return 0  # Dangerous: targeting direct child of home
+                            fi
                         fi
                         ;;
                 esac

--- a/scripts/test-rm-protection.sh
+++ b/scripts/test-rm-protection.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# Test script for rm command protection
+# Tests the dangerous rm detection and YubiKey verification flow
+# Part of igris (Iron Guardian Integration System)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOMB_DIR="${TOMB_DIR:-$(dirname "$SCRIPT_DIR")}"
+RM_WRAPPER="${TOMB_DIR}/scripts/rm-yubikey-wrapper.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Test counters
+PASSED=0
+FAILED=0
+
+# Print test result
+pass() {
+    echo -e "${GREEN}✅ PASS${NC}: $1"
+    ((PASSED++))
+}
+
+fail() {
+    echo -e "${RED}❌ FAIL${NC}: $1"
+    ((FAILED++))
+}
+
+# Header
+echo -e "\n${BLUE}═══════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}  rm Protection Test Suite${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════${NC}\n"
+
+# Check wrapper exists
+echo -e "${YELLOW}Checking prerequisites...${NC}"
+if [ -x "$RM_WRAPPER" ]; then
+    pass "rm wrapper script exists and is executable"
+else
+    fail "rm wrapper script not found at: $RM_WRAPPER"
+    exit 1
+fi
+
+echo ""
+echo -e "${YELLOW}Test 1: Safe rm operations (should pass through)${NC}"
+
+# Create test file
+TEST_FILE="/tmp/igris-rm-test-$$"
+touch "$TEST_FILE"
+
+# Safe rm should work without verification
+if /bin/rm "$TEST_FILE" 2>/dev/null; then
+    pass "Safe rm /tmp/file passed through"
+else
+    fail "Safe rm failed unexpectedly"
+fi
+
+echo ""
+echo -e "${YELLOW}Test 2: Dangerous flag detection${NC}"
+
+# Test various dangerous flag patterns
+check_dangerous_flags() {
+    local args="$1"
+    local expected="$2"
+    local description="$3"
+
+    # Source the wrapper to test has_dangerous_flags function
+    # We use TOMB_DRY_RUN to avoid actual verification
+    export TOMB_DRY_RUN=true
+    export TOMB_DANGEROUS_ENABLED=true
+
+    local output
+    output=$("$RM_WRAPPER" $args 2>&1) || true
+
+    if [[ "$output" == *"DANGEROUS"* ]]; then
+        if [ "$expected" = "dangerous" ]; then
+            pass "$description detected as dangerous"
+        else
+            fail "$description should NOT be dangerous, but was detected"
+        fi
+    else
+        if [ "$expected" = "safe" ]; then
+            pass "$description passed through as safe"
+        else
+            fail "$description should be dangerous, but was not detected"
+        fi
+    fi
+}
+
+# These should be detected as dangerous when targeting protected paths
+check_dangerous_flags "-rf ~" "dangerous" "rm -rf ~"
+check_dangerous_flags "-fr /" "dangerous" "rm -fr /"
+check_dangerous_flags "-r -f /Users" "dangerous" "rm -r -f /Users"
+check_dangerous_flags "-f -r /System" "dangerous" "rm -f -r /System"
+
+# These should be safe (no protected path or not recursive+force)
+check_dangerous_flags "/tmp/safe" "safe" "rm /tmp/safe"
+check_dangerous_flags "-r /tmp/dir" "safe" "rm -r /tmp/dir (no -f)"
+check_dangerous_flags "-f /tmp/file" "safe" "rm -f /tmp/file (no -r)"
+
+echo ""
+echo -e "${YELLOW}Test 3: Protected path detection${NC}"
+
+# Test protected paths
+protected_paths=("/" "~" "/Users" "/System" "/usr" "/opt" "/Applications" "/Library")
+
+for path in "${protected_paths[@]}"; do
+    check_dangerous_flags "-rf $path" "dangerous" "rm -rf $path"
+done
+
+echo ""
+echo -e "${YELLOW}Test 4: Environment detection${NC}"
+
+# Source wrapper to test detect_environment
+source "$RM_WRAPPER" 2>/dev/null || true
+
+# Check current environment
+if declare -f detect_environment > /dev/null 2>&1; then
+    env=$(detect_environment)
+    echo -e "Current environment: ${BLUE}$env${NC}"
+
+    if [ "$env" = "main" ]; then
+        pass "Detected main machine environment"
+    elif [ "$env" = "vm" ]; then
+        pass "Detected VM environment (protection would be skipped)"
+    else
+        echo -e "${YELLOW}⚠️${NC}  Unknown environment: $env"
+    fi
+else
+    echo -e "${YELLOW}⚠️${NC}  Could not test environment detection (function not exported)"
+fi
+
+echo ""
+echo -e "${YELLOW}Test 5: Bypass mode${NC}"
+
+# Test TOMB_DANGEROUS_ENABLED=false
+export TOMB_DANGEROUS_ENABLED=false
+TEST_FILE2="/tmp/igris-rm-test2-$$"
+touch "$TEST_FILE2"
+
+if "$RM_WRAPPER" "$TEST_FILE2" 2>/dev/null; then
+    pass "Bypass mode (TOMB_DANGEROUS_ENABLED=false) works"
+else
+    fail "Bypass mode failed"
+fi
+
+# Reset
+export TOMB_DANGEROUS_ENABLED=true
+
+# Summary
+echo ""
+echo -e "${BLUE}═══════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}  Test Results${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════${NC}"
+echo ""
+echo -e "Passed: ${GREEN}$PASSED${NC}"
+echo -e "Failed: ${RED}$FAILED${NC}"
+echo ""
+
+if [ "$FAILED" -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    exit 1
+fi

--- a/scripts/touchid-verify.sh
+++ b/scripts/touchid-verify.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration
-TIMEOUT_SECONDS="${YUBIKEY_TIMEOUT:-10}"
+TIMEOUT_SECONDS="${YUBIKEY_TIMEOUT:-30}"
 LOG_FILE="${HOME}/.tomb-yubikey-verifications.log"
 
 # Colors for output

--- a/scripts/yubikey-verify.sh
+++ b/scripts/yubikey-verify.sh
@@ -511,7 +511,15 @@ cleanup_verification_cache() {
     local temp_file="${cache_file}.tmp"
 
     # Filter out entries older than cache window
-    while IFS='|' read -r timestamp hash operation serial; do
+    while IFS='|' read -r timestamp hash operation serial || [[ -n "$timestamp" ]]; do
+        # Skip empty or malformed lines
+        if [ -z "$timestamp" ] || [ -z "$hash" ] || [ -z "$operation" ] || [ -z "$serial" ]; then
+            continue
+        fi
+        # Validate timestamp is numeric
+        if ! [[ "$timestamp" =~ ^[0-9]+$ ]]; then
+            continue
+        fi
         local age=$((current_time - timestamp))
         if [ "$age" -lt "$cache_window" ]; then
             echo "${timestamp}|${hash}|${operation}|${serial}" >> "$temp_file"
@@ -555,7 +563,15 @@ check_verification_cache() {
     local current_time=$(date +%s)
 
     # Search for matching entry within time window
-    while IFS='|' read -r timestamp hash operation serial; do
+    while IFS='|' read -r timestamp hash operation serial || [[ -n "$timestamp" ]]; do
+        # Skip empty or malformed lines
+        if [ -z "$timestamp" ] || [ -z "$hash" ] || [ -z "$operation" ] || [ -z "$serial" ]; then
+            continue
+        fi
+        # Validate timestamp is numeric
+        if ! [[ "$timestamp" =~ ^[0-9]+$ ]]; then
+            continue
+        fi
         local age=$((current_time - timestamp))
 
         # Check if entry matches current context and is within window
@@ -589,8 +605,12 @@ cache_successful_verification() {
     local timestamp=$(date +%s)
     local serial="${YUBIKEY_SERIAL:-unknown}"
 
+    # Sanitize operation field - remove pipe chars and newlines to prevent cache corruption
+    # Extract just the command type (e.g., "git push", "gh pr create") without arguments
+    local sanitized_operation=$(echo "${OPERATION:-unknown}" | tr '|' '_' | tr '\n' ' ' | cut -c1-100)
+
     # Append to cache file
-    echo "${timestamp}|${verification_hash}|${OPERATION}|${serial}" >> "$cache_file"
+    echo "${timestamp}|${verification_hash}|${sanitized_operation}|${serial}" >> "$cache_file"
     chmod 600 "$cache_file"  # Ensure user-only permissions
 
     print_info "Verification cached for 5 seconds"

--- a/scripts/yubikey-verify.sh
+++ b/scripts/yubikey-verify.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Configuration
-TIMEOUT_SECONDS="${YUBIKEY_TIMEOUT:-10}"
+TIMEOUT_SECONDS="${YUBIKEY_TIMEOUT:-30}"
 LOG_FILE="${HOME}/.tomb-yubikey-verifications.log"
 TOMB_DIR="${TOMB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 CONFIG_FILE="${TOMB_DIR}/configs/yubikey-enforcement.yml"


### PR DESCRIPTION
## Summary

Extends igris YubiKey-enforced security from git operations to dangerous `rm` commands (like `rm -rf ~/`), requiring physical hardware tap before execution.

**Motivation**: Reddit post showed Claude CLI accidentally running `rm -rf ~/` - this prevents that scenario with hardware verification. (if for whatever reason I dared to do such a thing, but better safe than sorry)

### Features
- `rm` command wrapper with dangerous flag detection (`-rf`, `-fr`, `-r -f`, etc.)
- Protected path list (`/`, `~`, `/Users`, `/System`, `/usr`, `/opt`, etc.)
- Main machine only - VM environments pass through without verification
- YubiKey only - no Touch ID fallback (can auto-succeed)
- Modular audio alerts for dangerous operations
- Opt-in via `--dangerous-commands` flag during setup

### Files Changed
- `configs/yubikey-enforcement.yml` - dangerous_commands schema
- `scripts/rm-yubikey-wrapper.sh` - new wrapper script
- `scripts/hardware-git-setup.sh` - --dangerous-commands flag
- `configs/audio-alerts.yml` - audio mapping
- `scripts/test-rm-protection.sh` - test suite
- `assets/audio/dangerous/README.md` - audio generation guide

## Test Plan

- [ ] Run `./scripts/test-rm-protection.sh` - all tests pass
- [ ] Install with `./scripts/hardware-git-setup.sh setup --dangerous-commands`
- [ ] Test safe rm: `rm /tmp/testfile` passes through
- [ ] Test dangerous rm: `rm -rf ~/test` requires YubiKey tap
- [ ] Test VM bypass: On VM, dangerous rm passes through
- [ ] Test bypass mode: `TOMB_DANGEROUS_ENABLED=false rm -rf ~/test` passes through