### PR TITLE
feat: igris v3.0.0 — Docker auth gating, Slot 1 migration, unified CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,30 @@ _Naming scheme derived from Solo Leveling because I decided why not ([Image Sour
 
 - **Hardware Verification Enforcement** - YubiKey tap OR Touch ID via 1Password CLI
 - **Git/GitHub Protection** - All network operations require hardware verification
+- **Docker Operation Gating** - Policy-based auth for Docker commands (auto-approve / single-tap / dual-tap)
 - **Dangerous Command Protection** - Block `rm -rf ~/` and similar catastrophic commands
+- **Unified CLI** - `igris status`, `igris audit`, `igris policy` for management
 - **Command-Specific Audio Alerts** - Modular voice notifications for each operation
 - **Defense-in-Depth Architecture** with multiple enforcement layers preventing bypass
 - **Environment-Aware** - Main machine protection, VM pass-through for sandboxed work
 - **Flexible Authentication** - Use YubiKey (most secure) or Touch ID (convenient alternative)
-- **Cryptographic Verification** via HMAC-SHA1 challenge-response with touch requirement
+- **Cryptographic Verification** via HMAC-SHA1 challenge-response (Slot 1, touch required)
 - **Bypass Detection Alerts** - Audio warnings when enforcement is disabled
 - **Auto-Revert Setup** ensuring no incomplete or misconfigured installations
-- **Comprehensive Audit Logging** for all verification attempts and failures
+- **Comprehensive Audit Logging** for all verification attempts and failures (JSONL for Docker, plaintext for git)
 - **Graceful Fallback** with security warnings when optimal verification unavailable
 
 **Operations Requiring Hardware Verification:**
 - `git push`, `git pull`, `git fetch`, `git clone`
 - `git remote add/update/set-url`, `git submodule update --remote`
 - `gh pr create/merge`, `gh release create`, `gh repo clone`, `gh workflow run`
+- `docker container start/stop/restart/run`, `docker compose up/down` (single tap)
+- `docker exec`, `docker container rm`, `docker system prune` (dual tap)
 - `rm -rf /`, `rm -rf ~`, `rm -rf /Users/*` (with `--dangerous-commands` flag)
 
 **Pass-Through Operations (No Tap):**
 - `git commit`, `git status`, `git log`, `git diff`
+- `docker ps`, `docker logs`, `docker images`, `docker inspect`, `docker info`
 - All read-only and local operations
 - `rm` commands not targeting protected paths
 - All commands in VM environments (sandbox mode)
@@ -58,10 +63,14 @@ Igris implements a defense-in-depth security model with three enforcement layers
 ├── Layer 2: Git Hooks
 │   └── pre-push hook               → Catches direct binary invocations
 │
-├── Layer 3: YubiKey Verification
+├── Layer 3: Docker Policy Engine
+│   ├── docker-yubikey-wrapper.sh  → Intercepts Docker commands
+│   └── policy.py                  → Classifies operations by risk
+│
+├── Layer 4: YubiKey Verification
 │   └── yubikey-verify.sh           → Cryptographic challenge-response
 │
-└── Layer 4: Audio Alerts
+└── Layer 5: Audio Alerts
     ├── Command-specific alerts     → "YubiKey tap required for git push"
     ├── Bypass detection            → "Warning: enforcement bypassed"
     └── Modular composition         → Reusable prefix + action clips
@@ -82,11 +91,21 @@ Igris implements a defense-in-depth security model with three enforcement layers
 3. Requires YubiKey verification again
 4. Aborts push if verification fails
 
+**Docker Policy Engine:**
+1. Shell wrapper intercepts Docker commands
+2. Fast path: regex pre-check for obvious read-only ops (skips Python startup)
+3. Python policy engine parses Docker CLI args into dotted operations
+4. Classifies as `auto_approve`, `single_tap`, or `dual_tap`
+5. `auto_approve`: executes immediately (read-only ops)
+6. `single_tap`: requires one YubiKey tap
+7. `dual_tap`: requires two taps within 10-second window (destructive ops)
+8. All operations logged to `~/.cache/igris/audit.jsonl`
+
 **YubiKey Verification Core:**
 1. Plays command-specific audio alert (e.g., "YubiKey tap required for git push")
 2. Detects YubiKey presence via `ykman`
 3. Generates random 32-byte challenge
-4. Sends challenge to YubiKey OTP slot 2
+4. Sends challenge to YubiKey OTP Slot 1 (configurable via `IGRIS_OTP_SLOT`)
 5. Requires physical tap (hardware enforced)
 6. Validates HMAC-SHA1 response
 7. Logs attempt (success/failure/timeout)
@@ -102,7 +121,7 @@ Igris implements a defense-in-depth security model with three enforcement layers
 
 1. **YubiKey OTP with Required Touch** (MOST SECURE)
    - Cryptographic HMAC-SHA1 challenge-response
-   - Touch flag enforced on YubiKey slot 2
+   - Touch flag enforced on YubiKey Slot 1 (configurable)
    - Random 32-byte challenge per operation
    - Hardware-verified physical presence
    - Preferred method for maximum security
@@ -231,7 +250,15 @@ cd igris
 ```bash
 ./scripts/yubikey-configure-otp.sh configure
 ```
-This sets up HMAC-SHA1 challenge-response with required touch on slot 2.
+This sets up HMAC-SHA1 challenge-response with required touch on Slot 1.
+
+**YubiKey Slot Layout:**
+| Slot | Purpose |
+|------|---------|
+| Slot 1 (short touch) | HMAC-SHA1 for igris |
+| Slot 2 (long touch) | Static password / other |
+
+> Multiple YubiKeys: program the same HMAC-SHA1 secret onto Slot 1 of each key. Save the secret in 1Password for recovery.
 
 *If using Touch ID:*
 ```bash
@@ -244,12 +271,20 @@ op account list  # Should trigger Touch ID
 
 **3. Install Enforcement System:**
 ```bash
+# Git + GitHub CLI enforcement
 ./scripts/hardware-git-setup.sh setup
+
+# Git + GitHub + dangerous rm protection
+./scripts/hardware-git-setup.sh setup --dangerous-commands
+
+# Git + GitHub + dangerous rm + Docker operation gating
+./scripts/hardware-git-setup.sh setup --docker
 ```
 
 Interactive setup process:
 - Detects available hardware (YubiKey and/or Touch ID)
-- Installs shell wrappers for git/gh commands
+- Installs shell wrappers for git/gh commands (+ Docker if `--docker`)
+- Creates Docker policy at `~/.config/igris/policy.yaml` (if `--docker`)
 - Configures global git hooks via template directory
 - Backs up existing shell configuration
 - **Requires hardware verification to complete** (proves physical access)
@@ -268,6 +303,15 @@ source ~/.bashrc
 
 # Or restart your terminal
 ```
+
+**5. (Optional) Install the `igris` CLI:**
+```bash
+cd igris
+uv sync
+uv run igris status
+```
+
+The CLI provides `igris status`, `igris audit`, and `igris policy` commands for managing the system.
 
 ### First Use
 
@@ -364,8 +408,24 @@ This installs pre-push hooks in repositories listed in `configs/yubikey-enforcem
 | Task | Command | Description |
 |------|---------|-------------|
 | **Check Slot Status** | `./scripts/yubikey-configure-otp.sh status` | Show OTP configuration |
-| **Configure Slot 2** | `./scripts/yubikey-configure-otp.sh configure` | Setup challenge-response |
-| **Delete Slot 2** | `./scripts/yubikey-configure-otp.sh delete` | Remove OTP configuration |
+| **Configure Slot 1** | `./scripts/yubikey-configure-otp.sh configure` | Setup HMAC-SHA1 challenge-response |
+| **Delete Slot 1** | `./scripts/yubikey-configure-otp.sh delete` | Remove OTP configuration |
+
+### Docker Policy Management
+
+| Task | Command | Description |
+|------|---------|-------------|
+| **View Policy** | `igris policy` or `cat ~/.config/igris/policy.yaml` | Show Docker operation classifications |
+| **View Audit Log** | `igris audit --tail 20` | Recent Docker auth events |
+| **Check Status** | `igris status` | Enforcement status for git, Docker, environment |
+
+### Docker Auth Levels
+
+| Level | Operations | Behaviour |
+|-------|-----------|-----------|
+| `auto_approve` | `ps`, `logs`, `images`, `inspect`, `info`, `version`, `compose ps/logs` | No tap — passes through |
+| `single_tap` | `start`, `stop`, `restart`, `run`, `build`, `pull`, `compose up/down` | One YubiKey tap |
+| `dual_tap` | `exec`, `rm`, `kill`, `system prune`, `volume rm`, `compose rm` | Two taps within 10 seconds |
 
 ### Management Workflow
 
@@ -412,9 +472,9 @@ ykman list
 # Try different USB port
 ```
 
-**"OTP Slot 2 is empty":**
+**"OTP Slot 1 is empty":**
 ```bash
-# Configure OTP slot 2 with touch requirement
+# Configure OTP Slot 1 with touch requirement
 ./scripts/yubikey-configure-otp.sh configure
 
 # Verify configuration
@@ -604,13 +664,11 @@ exemptions:
 ### Contributing
 
 **Areas for Improvement:**
+- [ ] Interactive TUI for repo selection during setup
+- [ ] Serial allow-list enforcement (config exists, not wired up)
 - [ ] FIDO2 proper implementation (not just presence check)
 - [ ] Windows support (PowerShell wrappers)
-- [ ] GUI installer for non-technical users
-- [ ] Multi-YubiKey rotation support
-- [ ] Time-based caching (tap once, valid for N minutes)
 - [ ] Homebrew formula for easy installation
-- [ ] Automated integration tests
 - [ ] Keybase/GPG integration
 
 **Submitting Changes:**
@@ -628,29 +686,46 @@ exemptions:
 
 ```
 igris/
+├── src/igris/                        # Python package
+│   ├── cli.py                        # Unified `igris` CLI (Typer)
+│   ├── docker/
+│   │   ├── policy.py                 # Docker policy engine (auth classification)
+│   │   └── audit.py                  # JSONL audit logger
+│   ├── core/
+│   │   ├── otp.py                    # OTP password hashing/verification
+│   │   └── session.py                # Session management
+│   ├── api/                          # FastAPI REST backend (v2)
+│   │   ├── auth.py, keys.py, otp.py  # Auth endpoints
+│   │   └── sessions.py               # Session endpoints
+│   └── db/                           # Database models and migrations
 ├── scripts/
-│   ├── yubikey-verify.sh            # Core verification logic + audio
-│   ├── git-yubikey-wrapper.sh       # Git command wrapper
-│   ├── gh-yubikey-wrapper.sh        # GitHub CLI wrapper
-│   ├── rm-yubikey-wrapper.sh        # Dangerous rm command wrapper
-│   ├── hardware-git-setup.sh        # Management CLI
-│   ├── yubikey-configure-otp.sh     # YubiKey OTP configuration
-│   └── test-rm-protection.sh        # Test suite for rm protection
+│   ├── yubikey-verify.sh             # Core verification logic + audio
+│   ├── git-yubikey-wrapper.sh        # Git command wrapper
+│   ├── gh-yubikey-wrapper.sh         # GitHub CLI wrapper
+│   ├── rm-yubikey-wrapper.sh         # Dangerous rm command wrapper
+│   ├── docker-yubikey-wrapper.sh     # Docker command wrapper (policy-based)
+│   ├── hardware-git-setup.sh         # Management CLI (setup/remove/status)
+│   ├── yubikey-configure-otp.sh      # YubiKey OTP configuration
+│   ├── test-rm-protection.sh         # Test suite for rm protection
+│   └── test-docker-protection.sh     # Test suite for Docker protection
+├── tests/
+│   ├── test_docker_policy.py         # Policy engine tests (26 tests)
+│   ├── test_docker_audit.py          # Audit logger tests
+│   ├── test_otp.py                   # OTP verification tests
+│   └── test_session.py               # Session management tests
 ├── hooks/
 │   └── git-hooks/
-│       └── pre-push                  # Pre-push hook template
+│       └── pre-push                   # Pre-push hook template
 ├── configs/
-│   ├── yubikey-enforcement.yml       # Main configuration file (includes dangerous_commands)
-│   └── audio-alerts.yml              # Audio alert mappings (includes dangerous commands)
+│   ├── yubikey-enforcement.yml        # Main configuration (git, docker, dangerous_commands)
+│   └── audio-alerts.yml               # Audio alert mappings
+├── docs/
+│   ├── YUBIKEY_INTEGRATION_PLAN.md    # v2 REST API architecture
+│   └── USB-PASSTHROUGH.md             # USB passthrough for Docker/VMs
 ├── assets/
-│   └── audio/
-│       ├── README.md                 # Audio setup guide
-│       ├── prefix-*.wav              # Modular prefix clips
-│       ├── action-*.wav              # Modular action clips
-│       ├── bypass-detected.wav       # Security alert sound
-│       └── dangerous/                # Dangerous command audio files
-│           └── README.md             # Voice generation guide
-└── README.md                         # This file
+│   └── audio/                         # Voice clips and sounds
+├── pyproject.toml                     # Python package config (uv)
+└── README.md                          # This file
 ```
 
 ## Design Principles

--- a/configs/audio-alerts.yml
+++ b/configs/audio-alerts.yml
@@ -140,6 +140,73 @@ gh:
     category: write  # Uses prefix_sound_write
     description: "Run GitHub workflow"
 
+# Docker operations
+docker:
+  container_exec:
+    modular_audio: assets/audio/action-docker-exec.wav
+    category: security
+    description: "Docker exec into container (dual-tap)"
+
+  container_rm:
+    modular_audio: assets/audio/action-docker-rm.wav
+    category: security
+    description: "Docker remove container (dual-tap)"
+
+  container_run:
+    modular_audio: assets/audio/action-docker-run.wav
+    category: write
+    description: "Docker run container"
+
+  container_start:
+    modular_audio: assets/audio/action-docker-start.wav
+    category: write
+    description: "Docker start container"
+
+  container_stop:
+    modular_audio: assets/audio/action-docker-stop.wav
+    category: write
+    description: "Docker stop container"
+
+  container_restart:
+    modular_audio: assets/audio/action-docker-restart.wav
+    category: write
+    description: "Docker restart container"
+
+  image_pull:
+    modular_audio: assets/audio/action-docker-pull.wav
+    category: read
+    description: "Docker pull image"
+
+  image_build:
+    modular_audio: assets/audio/action-docker-build.wav
+    category: write
+    description: "Docker build image"
+
+  image_rm:
+    modular_audio: assets/audio/action-docker-rmi.wav
+    category: security
+    description: "Docker remove image (dual-tap)"
+
+  compose_up:
+    modular_audio: assets/audio/action-docker-compose-up.wav
+    category: write
+    description: "Docker compose up"
+
+  compose_down:
+    modular_audio: assets/audio/action-docker-compose-down.wav
+    category: write
+    description: "Docker compose down"
+
+  compose_rm:
+    modular_audio: assets/audio/action-docker-compose-rm.wav
+    category: security
+    description: "Docker compose rm (dual-tap)"
+
+  system_prune:
+    modular_audio: assets/audio/action-docker-prune.wav
+    category: security
+    description: "Docker system prune (dual-tap)"
+
 # 1Password Touch ID alerts
 onepassword:
   enabled: true  # Play sound when 1Password Touch ID prompt appears

--- a/configs/yubikey-enforcement.yml
+++ b/configs/yubikey-enforcement.yml
@@ -1,12 +1,17 @@
 # YubiKey Git Enforcement Configuration
-# Managed by tomb-of-nazarick/scripts/yubikey-git-setup.sh
-# Last updated: 2025-09-30
+# Managed by igris/scripts/hardware-git-setup.sh
+# Last updated: 2026-02-14
 
 enforcement:
   enabled: true                # Master switch for YubiKey enforcement
   require_tap: true            # Require physical tap (vs just presence)
   timeout_seconds: 30          # How long to wait for tap
   retry_attempts: 3            # Failed attempts before lockout warning
+
+yubikey:
+  slot: 1                       # OTP slot for HMAC-SHA1 challenge-response
+  # Override with IGRIS_OTP_SLOT env var
+  # Slot 1 = HMAC-SHA1 (igris), Slot 2 = Static password (VM login)
 
 verification:
   method: yubikey              # auto, yubikey, touchid
@@ -123,6 +128,14 @@ dangerous_commands:
   # chmod:
   #   enabled: false
   #   dangerous_patterns: ["777", "-R.*777", "000"]
+
+# Docker Operation Gating
+# Extends YubiKey verification to Docker commands based on risk level
+docker:
+  enabled: true
+  environment: main_only       # main_only | all (VM passes through)
+  # Policy file location (defaults to ~/.config/igris/policy.yaml)
+  policy_file: ~/.config/igris/policy.yaml
 
 devices:
   # Multiple YubiKeys can be registered for redundancy

--- a/docs/USB-PASSTHROUGH.md
+++ b/docs/USB-PASSTHROUGH.md
@@ -1,0 +1,167 @@
+# USB Passthrough for YubiKey in Docker
+
+This guide covers how to use physical YubiKey devices with the igris Docker container across different platforms.
+
+## Platform Support Matrix
+
+| Platform | FIDO2 Registration | FIDO2 Auth | OTP Auth | Notes |
+|---|---|---|---|---|
+| Linux (native Docker) | Direct USB mount | Direct USB mount | No USB needed | Best support |
+| macOS (Docker Desktop) | Host-mode only | Host-mode only | No USB needed | No USB passthrough |
+| macOS (Parallels VM) | USB forwarding | USB forwarding | No USB needed | Requires config |
+| Windows (Docker Desktop) | Host-mode only | Host-mode only | No USB needed | No USB passthrough |
+
+## Architecture
+
+```
+┌──────────────────────────────────┐
+│         Host Machine             │
+│                                  │
+│  ┌──────────┐  ┌──────────────┐  │
+│  │ YubiKey  │  │   igris      │  │
+│  │ (USB)    │  │ (host-mode)  │  │
+│  └────┬─────┘  └──────┬───────┘  │
+│       │               │          │
+│       │    Register    │          │
+│       └───────────────►│          │
+│                        │          │
+│              ┌─────────▼────────┐ │
+│              │   igris.db      │ │
+│              │  (shared vol)   │ │
+│              └─────────┬───────┘ │
+│                        │ mount   │
+│              ┌─────────▼───────┐ │
+│              │  igris Docker   │ │
+│              │  (validates     │ │
+│              │   sessions)     │ │
+│              └─────────────────┘ │
+└──────────────────────────────────┘
+```
+
+## Linux: Native USB Passthrough
+
+Linux Docker supports direct USB device access via device mounting.
+
+### Basic Setup
+
+```yaml
+# docker-compose.yml
+services:
+  igris:
+    # ... existing config ...
+    devices:
+      - /dev/bus/usb:/dev/bus/usb
+```
+
+### Targeted Device Mount (Recommended)
+
+More secure than mounting the entire USB bus:
+
+```bash
+# Find your YubiKey device path
+lsusb | grep Yubico
+# Example output: Bus 001 Device 042: ID 1050:0407 Yubico.com YubiKey OTP+FIDO+CCID
+
+# Mount specific device
+docker run -d \
+  --device /dev/bus/usb/001/042 \
+  -v igris-data:/data \
+  -p 8920:8920 \
+  igris
+```
+
+### udev Rules
+
+Create persistent device permissions:
+
+```bash
+# /etc/udev/rules.d/70-yubikey.rules
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1050", MODE="0660", GROUP="plugdev"
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="1050", MODE="0660", GROUP="plugdev"
+```
+
+Apply rules:
+
+```bash
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+## macOS: Host-Mode Registration
+
+Docker Desktop for macOS does not support USB passthrough. Use the host-mode pattern instead:
+
+### Pattern: Register on Host, Auth in Container
+
+1. **Run igris directly on host** for registration (requires USB access):
+
+```bash
+# Install igris on host
+uv sync
+
+# Start igris on host temporarily for registration
+IGRIS_DB_PATH=./data/igris.db \
+IGRIS_DB_MASTER_KEY_FILE=./data/.igris-master-key \
+uv run uvicorn igris.main:app --host 127.0.0.1 --port 8920
+```
+
+2. **Register your YubiKey** via the FIDO2 endpoints (key physically connected to host).
+
+3. **Stop host igris**, mount the database into Docker:
+
+```yaml
+# docker-compose.yml
+services:
+  igris:
+    volumes:
+      - ./data:/data  # Contains igris.db with registered key
+```
+
+4. **Auth from container**: For FIDO2 auth, the ceremony requires the physical key on the host — use host-mode for FIDO2 flows. For OTP auth, no USB is needed (password-based).
+
+### OTP: The USB-Free Alternative
+
+OTP authentication does not require USB passthrough at all. Once a key is registered, configure an OTP credential:
+
+```bash
+# Register OTP credential (one-time, after FIDO2 key registration)
+curl -X POST http://localhost:8920/auth/otp/register \
+  -H 'Content-Type: application/json' \
+  -d '{"yubikey_serial": "12345678", "password": "your-long-tap-output"}'
+
+# Authenticate via OTP (no USB needed)
+curl -X POST http://localhost:8920/auth/otp/verify \
+  -H 'Content-Type: application/json' \
+  -d '{"password": "your-long-tap-output"}'
+```
+
+## Parallels Desktop: USB Forwarding
+
+For macOS VMs running under Parallels Desktop Pro, USB devices can be forwarded to the VM.
+
+### Configuration
+
+1. **Parallels settings**: VM Configuration > Hardware > USB
+2. **Add YubiKey**: Select "Yubico YubiKey" from device list
+3. **Persistent assignment**: Enable "Connect to this virtual machine" for the YubiKey serial
+
+### Persistent Assignment by Serial
+
+```bash
+# List connected USB devices in VM
+system_profiler SPUSBDataType | grep -A 5 "YubiKey"
+
+# Verify device is accessible
+# The YubiKey should appear as a HID device
+ls /dev/hidraw* 2>/dev/null || echo "No HID devices (expected on macOS)"
+```
+
+Once USB is forwarded to the Parallels VM, Linux Docker USB passthrough works normally within the VM.
+
+## Security Considerations
+
+- **Never use `--privileged`**: This grants full device access and disables security features
+- **Prefer `--device` over volume mounts**: More targeted, less attack surface
+- **OTP flow never requires USB**: Use OTP for containerized/VM environments where USB is impractical
+- **Database encryption**: igris uses sqlcipher when available — the database file contains credential hashes, not raw keys
+- **Network isolation**: Bind igris to localhost or trusted subnets only

--- a/docs/YUBIKEY_INTEGRATION_PLAN.md
+++ b/docs/YUBIKEY_INTEGRATION_PLAN.md
@@ -1,0 +1,301 @@
+# 🇺🇸🔐 igris: YubiKey-Gated Privilege Escalation
+
+> Physical authentication for AI agent permission boundaries
+
+---
+
+## Overview
+
+igris becomes the security boundary between planning (Claude.app) and execution (Claude Code CLI + Gemini sub-agents). A YubiKey tap is required to escalate from read-only planning mode to full execution permissions.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         Planning Layer                          │
+│  ┌─────────────┐                                                │
+│  │ Claude.app  │  Research, plan, discuss                       │
+│  │ (this chat) │  No filesystem writes, no code execution       │
+│  └──────┬──────┘                                                │
+│         │                                                       │
+│         │ "Ready to execute"                                    │
+│         ▼                                                       │
+│  ┌─────────────┐     ┌─────────────┐     ┌─────────────────┐   │
+│  │    igris    │────▶│  YubiKey    │────▶│ Session Token   │   │
+│  │   elevate   │     │  FIDO2 tap  │     │ (time-limited)  │   │
+│  └─────────────┘     └─────────────┘     └────────┬────────┘   │
+│                                                    │            │
+└────────────────────────────────────────────────────┼────────────┘
+                                                     │
+┌────────────────────────────────────────────────────┼────────────┐
+│                      Execution Layer               │            │
+│                                                    ▼            │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │                  Claude Code CLI                         │   │
+│  │  + Gemini sub-agents (pleiades-agents)                   │   │
+│  │                                                          │   │
+│  │  Full permissions: filesystem, code execution, network   │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Core Features
+
+### `igris elevate`
+
+Requests YubiKey tap to unlock execution permissions.
+
+```bash
+$ igris elevate
+🔐 Requesting elevated permissions...
+👆 Touch your YubiKey to continue
+
+✅ Elevated session started
+   Expires: 30 minutes (or next `igris lock`)
+   Scope: ~/projects, ~/artificial-roundtable
+```
+
+**Implementation options:**
+- FIDO2/WebAuthn via `python-fido2` library
+- Or shell out to `ykman` (YubiKey Manager CLI)
+
+### `igris lock`
+
+Immediately revokes elevated session.
+
+```bash
+$ igris lock
+🔒 Elevated session terminated
+   Returning to planning mode
+```
+
+### `igris status`
+
+Shows current permission level.
+
+```bash
+$ igris status
+Mode: ELEVATED
+Expires: 18 minutes remaining
+Last elevated: 2026-01-24 14:32:00
+Scope: ~/projects, ~/artificial-roundtable
+```
+
+### `igris guard <path>`
+
+Marks directories for extra protection (requires elevation even for reads in some cases).
+
+```bash
+$ igris guard ~/artificial-roundtable/voice-fingerprint
+🛡️ Path guarded: ~/artificial-roundtable/voice-fingerprint
+   Requires elevation for: read, write, execute
+```
+
+---
+
+## Session Management
+
+| Parameter | Default | Configurable |
+|-----------|---------|--------------|
+| Session timeout | 30 min | Yes, in config |
+| Auto-lock on idle | 10 min | Yes |
+| Require re-tap for sensitive paths | Yes | Per-path |
+| Session scope | Specified dirs | Yes |
+
+### Session Storage
+
+Session tokens stored in:
+- `~/.igris/session.json` (encrypted with YubiKey-derived key)
+- Or environment variable for current shell only
+
+```json
+{
+  "token": "encrypted-session-token",
+  "created_at": "2026-01-24T14:32:00Z",
+  "expires_at": "2026-01-24T15:02:00Z",
+  "scope": ["~/projects", "~/artificial-roundtable"],
+  "yubikey_serial": "12345678"
+}
+```
+
+---
+
+## Integration with Claude Code CLI
+
+### Pre-execution Hook
+
+Claude Code CLI checks igris before any write/execute operation:
+
+```python
+# Pseudo-code for Claude Code integration
+def before_action(action_type, path):
+    if action_type in ['write', 'execute', 'delete']:
+        if not igris.is_elevated():
+            raise PermissionError("Run `igris elevate` first")
+        if igris.is_guarded(path):
+            if not igris.check_guard_permission(path):
+                raise PermissionError(f"Path {path} requires explicit elevation")
+```
+
+### Gemini Sub-agent Permissions
+
+Gemini sub-agents inherit the igris session from parent Claude Code process:
+- Session token passed via environment
+- Sub-agents cannot elevate themselves
+- Any elevation request bubbles up to user
+
+---
+
+## Configuration
+
+`~/.igris/config.yaml`:
+
+```yaml
+# igris configuration
+
+session:
+  default_timeout_minutes: 30
+  idle_timeout_minutes: 10
+  require_yubikey: true
+
+yubikey:
+  # Restrict to specific YubiKey serial (optional)
+  allowed_serials:
+    - "12345678"
+  
+  # FIDO2 relying party ID
+  rp_id: "igris.local"
+
+guarded_paths:
+  # Always require elevation
+  - path: "~/artificial-roundtable/voice-fingerprint"
+    level: "strict"  # read+write+execute require elevation
+  
+  - path: "~/artificial-roundtable"
+    level: "write"   # only writes require elevation
+  
+  - path: "~/.ssh"
+    level: "strict"
+
+# Paths that never require elevation (safe zone)
+safe_paths:
+  - "~/scratch"
+  - "/tmp"
+
+logging:
+  enabled: true
+  path: "~/.igris/audit.log"
+```
+
+---
+
+## USB Passthrough (VM Integration)
+
+For M4 Max VM usage:
+
+1. YubiKey connected to host Mac
+2. USB passthrough configured to VM
+3. igris in VM sees YubiKey as local device
+
+```bash
+# On VM, verify YubiKey is visible
+$ ykman info
+Device type: YubiKey 5 NFC
+Serial number: 12345678
+...
+```
+
+### Apple Shortcuts Integration (Future)
+
+Potential workflow:
+1. Shortcut triggered: "Elevate igris session"
+2. Shortcut sends command to VM via SSH
+3. VM's igris prompts for YubiKey tap
+4. Session elevated
+
+This enables voice-triggered elevation: "Hey Siri, elevate igris"
+
+---
+
+## Audit Logging
+
+All elevation events logged:
+
+```
+2026-01-24 14:32:00 | ELEVATE | yubikey:12345678 | scope:~/projects,~/artificial-roundtable | timeout:30m
+2026-01-24 14:45:22 | ACCESS  | path:~/artificial-roundtable/voice-fingerprint | action:read | granted
+2026-01-24 15:01:00 | LOCK    | reason:manual | session_duration:29m
+```
+
+---
+
+## Resume/Portfolio Value
+
+This project demonstrates:
+
+| Skill | Evidence |
+|-------|----------|
+| Security architecture | Physical auth for privilege escalation |
+| FIDO2/WebAuthn | YubiKey integration |
+| Systems design | Session management, scope control |
+| Python | Implementation |
+| DevSecOps | Audit logging, principle of least privilege |
+
+Can be open-sourced (minus personal config) as a portfolio piece.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core CLI (MVP)
+- [ ] `igris elevate` with YubiKey FIDO2
+- [ ] `igris lock`
+- [ ] `igris status`
+- [ ] Basic session timeout
+
+### Phase 2: Path Guarding
+- [ ] `igris guard <path>`
+- [ ] Config file support
+- [ ] Audit logging
+
+### Phase 3: Integrations
+- [ ] Claude Code CLI hook
+- [ ] Gemini sub-agent inheritance
+- [ ] Apple Shortcuts trigger
+
+### Phase 4: Polish
+- [ ] Visual indicators (Hammerspoon glow when elevated?)
+- [ ] Stream Deck integration
+- [ ] Documentation for open source release
+
+---
+
+## Dependencies
+
+```
+python-fido2    # FIDO2/WebAuthn library
+pyyaml          # Config parsing
+click           # CLI framework
+cryptography    # Session encryption
+```
+
+Or if shelling out to ykman:
+```
+yubikey-manager # brew install ykman
+```
+
+---
+
+## Open Questions
+
+1. **Session encryption**: Use YubiKey's PIV for deriving encryption key, or simpler approach?
+2. **Multi-YubiKey**: Support multiple registered keys for backup?
+3. **Remote elevation**: Allow elevation via SSH with agent forwarding?
+4. **Integration depth**: Hook into shell (bash/zsh) or just CLI tools?
+
+---
+
+*Planning doc for Claude Code CLI handoff*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "igris"
-version = "2.0.0"
+version = "2.1.0"
 description = "YubiKey FIDO2 authentication service for LAN-based security enforcement"
 readme = "README.md"
 license = {text = "MIT"}
@@ -10,6 +10,7 @@ dependencies = [
     "uvicorn[standard]>=0.34.0",
     "fido2>=1.2.0",
     "pydantic-settings>=2.7.0",
+    "argon2-cffi>=23.1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "igris"
-version = "2.1.0"
-description = "YubiKey FIDO2 authentication service for LAN-based security enforcement"
+version = "3.0.0"
+description = "YubiKey-gated security enforcement for git, Docker, and shell operations"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12"
@@ -11,7 +11,12 @@ dependencies = [
     "fido2>=1.2.0",
     "pydantic-settings>=2.7.0",
     "argon2-cffi>=23.1.0",
+    "typer>=0.15.0",
+    "pyyaml>=6.0",
 ]
+
+[project.scripts]
+igris = "igris.cli:app"
 
 [project.optional-dependencies]
 sqlcipher = [

--- a/scripts/docker-yubikey-wrapper.sh
+++ b/scripts/docker-yubikey-wrapper.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+# Docker Hardware Verification Wrapper
+# Intercepts docker commands and requires YubiKey verification based on policy
+# Part of Igris security enforcement system
+
+set -euo pipefail
+
+# Get the actual Docker binary (not this wrapper)
+DOCKER_BINARY="${IGRIS_DOCKER_BINARY:-}"
+if [ -z "$DOCKER_BINARY" ]; then
+    # Search PATH for the real docker binary, skipping shell functions
+    DOCKER_BINARY=$(command -v docker 2>/dev/null || true)
+    if [ -z "$DOCKER_BINARY" ]; then
+        echo "❌ Docker binary not found" >&2
+        exit 1
+    fi
+fi
+
+TOMB_DIR="${TOMB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+VERIFY_SCRIPT="${TOMB_DIR}/scripts/hardware-verify.sh"
+
+# VM environment detection — pass through without verification
+if [[ "$(whoami)" == *vm ]]; then
+    exec "$DOCKER_BINARY" "$@"
+fi
+
+# Enforcement toggle — pass through if disabled
+if [ "${IGRIS_DOCKER_ENABLED:-true}" = "false" ]; then
+    exec "$DOCKER_BINARY" "$@"
+fi
+
+# Master enforcement toggle
+if [ "${TOMB_YUBIKEY_ENABLED:-true}" = "false" ]; then
+    exec "$DOCKER_BINARY" "$@"
+fi
+
+# If no arguments, pass through
+if [ $# -eq 0 ]; then
+    exec "$DOCKER_BINARY"
+fi
+
+# ============================================================================
+# FAST PATH: Regex pre-check for obvious auto-approve commands
+# Avoids Python startup latency on read-only operations
+# ============================================================================
+
+# Skip global flags to find the actual command
+args=("$@")
+idx=0
+while [ $idx -lt ${#args[@]} ] && [[ "${args[$idx]}" == -* ]]; do
+    # Flags that take a value
+    case "${args[$idx]}" in
+        -H|--host|--context|--config|--log-level|-l)
+            idx=$((idx + 2))
+            ;;
+        *)
+            idx=$((idx + 1))
+            ;;
+    esac
+done
+
+first_cmd="${args[$idx]:-}"
+second_cmd="${args[$((idx + 1))]:-}"
+
+# Auto-approve patterns (no YubiKey needed)
+case "$first_cmd" in
+    ps|logs|images|info|version|inspect|events|search|stats|top|diff|port|wait|history)
+        exec "$DOCKER_BINARY" "$@"
+        ;;
+    container)
+        case "$second_cmd" in
+            ls|list|logs|inspect|top|stats|diff|port|wait)
+                exec "$DOCKER_BINARY" "$@"
+                ;;
+        esac
+        ;;
+    image)
+        case "$second_cmd" in
+            ls|list|inspect|history)
+                exec "$DOCKER_BINARY" "$@"
+                ;;
+        esac
+        ;;
+    network|volume)
+        case "$second_cmd" in
+            ls|list|inspect)
+                exec "$DOCKER_BINARY" "$@"
+                ;;
+        esac
+        ;;
+    compose)
+        case "$second_cmd" in
+            ps|logs|config|ls|list)
+                exec "$DOCKER_BINARY" "$@"
+                ;;
+        esac
+        ;;
+esac
+
+# ============================================================================
+# POLICY ENGINE: Classify remaining commands via Python
+# ============================================================================
+
+# Build Python command to classify
+classification=$(python3 -c "
+import sys
+sys.path.insert(0, '${TOMB_DIR}/src')
+from igris.docker.policy import classify_docker_command, PolicyConfig, AuthLevel
+from pathlib import Path
+
+policy_path = Path.home() / '.config' / 'igris' / 'policy.yaml'
+policy = PolicyConfig.load(policy_path)
+args = sys.argv[1:]
+operation, level = classify_docker_command(args, policy)
+print(f'{operation}|{level.value}')
+" "$@" 2>/dev/null) || true
+
+if [ -z "$classification" ]; then
+    # Python classification failed — default to single_tap (safe)
+    classification="unknown|single_tap"
+fi
+
+operation="${classification%%|*}"
+auth_level="${classification##*|}"
+
+# ============================================================================
+# ENFORCEMENT
+# ============================================================================
+
+audit_entry() {
+    local outcome="$1"
+    python3 -c "
+import sys
+sys.path.insert(0, '${TOMB_DIR}/src')
+from igris.docker.audit import log_entry
+log_entry(
+    operation='${operation}',
+    auth_level='${auth_level}',
+    outcome='${outcome}',
+    raw_command='docker $*',
+)
+" 2>/dev/null || true
+}
+
+case "$auth_level" in
+    auto_approve)
+        audit_entry "approved"
+        exec "$DOCKER_BINARY" "$@"
+        ;;
+
+    single_tap)
+        if [ -x "$VERIFY_SCRIPT" ]; then
+            if ! "$VERIFY_SCRIPT" "docker ${operation}"; then
+                audit_entry "denied"
+                echo "❌ Hardware verification failed. Docker operation aborted." >&2
+                exit 1
+            fi
+        else
+            echo "⚠️  Warning: Hardware verification script not found at: $VERIFY_SCRIPT" >&2
+            echo "⚠️  Proceeding without verification — this is a security risk!" >&2
+        fi
+        audit_entry "approved"
+        exec "$DOCKER_BINARY" "$@"
+        ;;
+
+    dual_tap)
+        echo "🔒 Dual-tap required for: docker ${operation}" >&2
+        if [ -x "$VERIFY_SCRIPT" ]; then
+            # First tap (can use cache)
+            echo "👆 First YubiKey tap..." >&2
+            if ! "$VERIFY_SCRIPT" "docker ${operation} [tap 1/2]"; then
+                audit_entry "denied"
+                echo "❌ First tap failed. Docker operation aborted." >&2
+                exit 1
+            fi
+
+            # Second tap (cache disabled — forces fresh verification)
+            echo "" >&2
+            echo "👆 Second YubiKey tap required (confirmation)..." >&2
+            sleep 1  # Brief pause between taps
+            if ! TOMB_VERIFICATION_CACHE_ENABLED=false "$VERIFY_SCRIPT" "docker ${operation} [tap 2/2]"; then
+                audit_entry "denied"
+                echo "❌ Second tap failed. Docker operation aborted." >&2
+                exit 1
+            fi
+        else
+            echo "⚠️  Warning: Hardware verification script not found at: $VERIFY_SCRIPT" >&2
+            echo "⚠️  Proceeding without verification — this is a security risk!" >&2
+        fi
+        audit_entry "approved"
+        exec "$DOCKER_BINARY" "$@"
+        ;;
+
+    *)
+        # Unknown auth level — default to single_tap
+        if [ -x "$VERIFY_SCRIPT" ]; then
+            if ! "$VERIFY_SCRIPT" "docker ${operation}"; then
+                audit_entry "denied"
+                echo "❌ Hardware verification failed. Docker operation aborted." >&2
+                exit 1
+            fi
+        fi
+        audit_entry "approved"
+        exec "$DOCKER_BINARY" "$@"
+        ;;
+esac

--- a/scripts/hardware-git-setup.sh
+++ b/scripts/hardware-git-setup.sh
@@ -12,6 +12,7 @@ VERIFY_SCRIPT="${TOMB_DIR}/scripts/yubikey-verify.sh"
 GIT_WRAPPER="${TOMB_DIR}/scripts/git-yubikey-wrapper.sh"
 GH_WRAPPER="${TOMB_DIR}/scripts/gh-yubikey-wrapper.sh"
 RM_WRAPPER="${TOMB_DIR}/scripts/rm-yubikey-wrapper.sh"
+DOCKER_WRAPPER="${TOMB_DIR}/scripts/docker-yubikey-wrapper.sh"
 PRE_PUSH_HOOK="${TOMB_DIR}/hooks/git-hooks/pre-push"
 CONFIG_FILE="${TOMB_DIR}/configs/yubikey-enforcement.yml"
 BACKUP_DIR="${HOME}/.tomb-yubikey-backup"
@@ -70,11 +71,13 @@ OPTIONS:
     --repo <path>        Target specific repository
     --non-interactive    Skip prompts and use defaults
     --dangerous-commands Install rm wrapper for dangerous command protection
+    --docker             Install Docker wrapper for operation gating
 
 EXAMPLES:
     $(basename "$0") setup                        # Interactive setup with prompts
     $(basename "$0") setup --all-repos            # Install + add hooks to all repos
     $(basename "$0") setup --dangerous-commands   # Also protect dangerous rm commands
+    $(basename "$0") setup --docker               # Also protect Docker operations
     $(basename "$0") status                       # Check current status
     $(basename "$0") disable                      # Temporarily disable (keep config)
     $(basename "$0") test                         # Test YubiKey verification
@@ -221,6 +224,7 @@ cmd_setup() {
     local interactive=true
     local install_all_repos=false
     local install_dangerous_commands=false
+    local install_docker=false
 
     # Parse options
     while [[ $# -gt 0 ]]; do
@@ -235,6 +239,10 @@ cmd_setup() {
                 ;;
             --dangerous-commands)
                 install_dangerous_commands=true
+                shift
+                ;;
+            --docker)
+                install_docker=true
                 shift
                 ;;
             *)
@@ -346,6 +354,19 @@ EOF
             install_rm_wrapper "$shell_config"
         else
             print_info "Skipped rm protection (you can add later with --dangerous-commands)"
+        fi
+    fi
+
+    # Install Docker wrapper if requested
+    if [ "$install_docker" = true ]; then
+        install_docker_wrapper "$shell_config"
+    elif [ "$interactive" = true ]; then
+        echo ""
+        print_info "Docker operation gating is available (requires YubiKey for destructive ops)."
+        if confirm_action "Also install Docker protection?" "no"; then
+            install_docker_wrapper "$shell_config"
+        else
+            print_info "Skipped Docker protection (you can add later with --docker)"
         fi
     fi
 
@@ -476,6 +497,166 @@ rm() {
 EOF
 
     print_success "rm wrapper installed - dangerous operations require YubiKey"
+}
+
+# Install Docker wrapper for operation gating
+install_docker_wrapper() {
+    local shell_config="$1"
+
+    print_info "Installing Docker operation gating..."
+
+    # Check if already installed
+    if grep -q "Docker Operation Gating" "$shell_config" 2>/dev/null; then
+        print_warning "Docker wrapper already installed in $shell_config"
+        return 0
+    fi
+
+    # Resolve Docker binary at install time
+    local docker_bin
+    docker_bin=$(command -v docker 2>/dev/null || true)
+    if [ -z "$docker_bin" ]; then
+        print_warning "Docker binary not found — wrapper will search PATH at runtime"
+        docker_bin=""
+    fi
+
+    cat >> "$shell_config" << EOF
+
+# Docker Operation Gating (managed by igris)
+# Requires YubiKey for state-changing Docker operations
+# Only enforces on main machine — VM environments pass through
+export IGRIS_DOCKER_ENABLED=true
+EOF
+
+    # Only export binary path if we found one
+    if [ -n "$docker_bin" ]; then
+        cat >> "$shell_config" << EOF
+export IGRIS_DOCKER_BINARY="${docker_bin}"
+EOF
+    fi
+
+    cat >> "$shell_config" << EOF
+
+docker() {
+    "$DOCKER_WRAPPER" "\$@"
+}
+
+EOF
+
+    # Also handle docker-compose standalone binary if present
+    if command -v docker-compose &>/dev/null; then
+        cat >> "$shell_config" << EOF
+docker-compose() {
+    "$DOCKER_WRAPPER" compose "\$@"
+}
+
+EOF
+    fi
+
+    # Create default policy file
+    install_docker_policy
+
+    print_success "Docker wrapper installed — operations gated by policy"
+}
+
+# Install default Docker policy file
+install_docker_policy() {
+    local policy_dir="${HOME}/.config/igris"
+    local policy_file="${policy_dir}/policy.yaml"
+
+    if [ -f "$policy_file" ]; then
+        print_info "Docker policy already exists: $policy_file"
+        return 0
+    fi
+
+    mkdir -p "$policy_dir"
+
+    cat > "$policy_file" << 'EOF'
+# igris Docker Operation Policy
+# Controls which Docker commands require YubiKey verification
+#
+# Levels:
+#   auto_approve - No verification needed (read-only operations)
+#   single_tap   - One YubiKey tap required (state-changing operations)
+#   dual_tap     - Two YubiKey taps required (destructive operations)
+
+policy:
+  auto_approve:
+    - container.logs
+    - container.list
+    - container.inspect
+    - container.top
+    - container.stats
+    - container.diff
+    - container.port
+    - container.wait
+    - image.list
+    - image.inspect
+    - image.history
+    - network.list
+    - network.inspect
+    - volume.list
+    - volume.inspect
+    - compose.ps
+    - compose.logs
+    - compose.config
+    - info
+    - version
+    - events
+    - search
+
+  single_tap:
+    - container.start
+    - container.stop
+    - container.restart
+    - container.create
+    - container.run
+    - container.pause
+    - container.unpause
+    - container.rename
+    - container.update
+    - container.cp
+    - container.commit
+    - container.export
+    - container.attach
+    - image.pull
+    - image.build
+    - image.tag
+    - image.save
+    - image.load
+    - image.push
+    - network.create
+    - network.connect
+    - network.disconnect
+    - volume.create
+    - compose.up
+    - compose.down
+    - compose.restart
+    - compose.build
+    - compose.pull
+    - compose.start
+    - compose.stop
+    - compose.create
+    - login
+    - logout
+
+  dual_tap:
+    - container.exec
+    - container.rm
+    - container.kill
+    - image.rm
+    - volume.rm
+    - network.rm
+    - compose.rm
+    - system.prune
+    - builder.prune
+    - image.prune
+    - container.prune
+    - network.prune
+    - volume.prune
+EOF
+
+    chmod 600 "$policy_file"
+    print_success "Default Docker policy created: $policy_file"
 }
 
 # Install hooks in workspace repos
@@ -617,6 +798,16 @@ cmd_status() {
         echo -e "rm protect:  ${GREEN}✅ Installed${NC} (dangerous rm requires YubiKey)"
     else
         echo -e "rm protect:  ${YELLOW}⚠️  Not installed${NC} (add with --dangerous-commands)"
+    fi
+
+    # Check Docker wrapper
+    if grep -q "Docker Operation Gating" "$shell_config" 2>/dev/null; then
+        echo -e "Docker:      ${GREEN}✅ Installed${NC} (operations gated by policy)"
+        if [ -f "${HOME}/.config/igris/policy.yaml" ]; then
+            echo -e "             Policy: ~/.config/igris/policy.yaml"
+        fi
+    else
+        echo -e "Docker:      ${YELLOW}⚠️  Not installed${NC} (add with --docker)"
     fi
 
     # Check hooks
@@ -766,6 +957,16 @@ cmd_remove() {
         print_success "Removed rm wrapper from shell config"
     else
         print_info "No rm wrapper found in shell config"
+    fi
+
+    # Remove Docker wrapper
+    if grep -q "Docker Operation Gating" "$shell_config" 2>/dev/null; then
+        sed -i.bak '/# Docker Operation Gating/,/^$/d' "$shell_config"
+        # Also remove docker-compose wrapper if present
+        sed -i.bak '/^docker-compose()/,/^$/d' "$shell_config"
+        print_success "Removed Docker wrapper from shell config"
+    else
+        print_info "No Docker wrapper found in shell config"
     fi
 
     # Remove git hooks from template

--- a/scripts/test-docker-protection.sh
+++ b/scripts/test-docker-protection.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Docker Protection Integration Tests
+# Tests the Docker YubiKey wrapper with mock Docker binary
+# Part of igris security enforcement system
+
+set -euo pipefail
+
+TOMB_DIR="${TOMB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WRAPPER="${TOMB_DIR}/scripts/docker-yubikey-wrapper.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1"
+    local expected_exit="$2"
+    shift 2
+
+    local actual_exit=0
+    "$@" >/dev/null 2>&1 || actual_exit=$?
+
+    if [ "$actual_exit" -eq "$expected_exit" ]; then
+        echo -e "  ${GREEN}PASS${NC} $desc"
+        PASS=$((PASS + 1))
+    else
+        echo -e "  ${RED}FAIL${NC} $desc (expected exit=$expected_exit, got=$actual_exit)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Docker Protection Integration Tests ==="
+echo ""
+
+# Common env for tests
+export TOMB_DIR
+export IGRIS_DOCKER_BINARY=echo
+export TOMB_YUBIKEY_ENABLED=true
+export IGRIS_DOCKER_ENABLED=true
+
+# --- Auto-approve tests (should pass through without YubiKey) ---
+echo "Auto-approve (should pass through):"
+check "docker ps" 0 "$WRAPPER" ps
+check "docker logs container" 0 "$WRAPPER" logs mycontainer
+check "docker images" 0 "$WRAPPER" images
+check "docker info" 0 "$WRAPPER" info
+check "docker version" 0 "$WRAPPER" version
+check "docker inspect container" 0 "$WRAPPER" inspect mycontainer
+check "docker compose ps" 0 "$WRAPPER" compose ps
+check "docker compose logs" 0 "$WRAPPER" compose logs
+check "docker stats" 0 "$WRAPPER" stats
+check "docker top container" 0 "$WRAPPER" top mycontainer
+check "docker container ls" 0 "$WRAPPER" container ls
+check "docker image ls" 0 "$WRAPPER" image ls
+check "docker network ls" 0 "$WRAPPER" network ls
+check "docker volume ls" 0 "$WRAPPER" volume ls
+echo ""
+
+# --- Enforcement disabled tests ---
+echo "Enforcement disabled (should pass through):"
+IGRIS_DOCKER_ENABLED=false check "IGRIS_DOCKER_ENABLED=false bypasses exec" 0 "$WRAPPER" exec container bash
+TOMB_YUBIKEY_ENABLED=false IGRIS_DOCKER_ENABLED=true check "TOMB_YUBIKEY_ENABLED=false bypasses exec" 0 "$WRAPPER" exec container bash
+
+# Restore
+export TOMB_YUBIKEY_ENABLED=true
+export IGRIS_DOCKER_ENABLED=true
+echo ""
+
+# --- VM bypass tests ---
+echo "VM bypass:"
+if [[ "$(whoami)" == *vm ]]; then
+    check "VM user passes through exec" 0 "$WRAPPER" exec container bash
+    check "VM user passes through rm" 0 "$WRAPPER" rm container
+    check "VM user passes through system prune" 0 "$WRAPPER" system prune
+else
+    echo -e "  ${YELLOW}SKIP${NC} Not running on VM (user=$(whoami))"
+fi
+
+echo ""
+
+# --- Summary ---
+echo "=== Results ==="
+echo -e "  ${GREEN}Passed: $PASS${NC}"
+if [ $FAIL -gt 0 ]; then
+    echo -e "  ${RED}Failed: $FAIL${NC}"
+    exit 1
+else
+    echo -e "  Failed: $FAIL"
+    echo ""
+    echo "All tests passed!"
+fi

--- a/scripts/yubikey-configure-otp.sh
+++ b/scripts/yubikey-configure-otp.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 
 # YubiKey OTP Configuration Helper
-# Manages OTP Slot 2 for challenge-response with REQUIRED physical touch
-# Part of tomb-of-nazarick security system
+# Manages OTP slot for HMAC-SHA1 challenge-response with REQUIRED physical touch
+# Part of igris security system
 
 set -euo pipefail
+
+# Configuration
+TOMB_DIR="${TOMB_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CONFIG_FILE="${TOMB_DIR}/configs/yubikey-enforcement.yml"
+
+# Read OTP slot from config/env (default: 1)
+if [ -z "${IGRIS_OTP_SLOT:-}" ] && [ -f "$CONFIG_FILE" ]; then
+    IGRIS_OTP_SLOT=$(grep -A 5 "^yubikey:" "$CONFIG_FILE" 2>/dev/null | grep "slot:" | head -1 | awk '{print $2}')
+fi
+SLOT="${IGRIS_OTP_SLOT:-1}"
 
 # Colors
 RED='\033[0;31m'
@@ -38,26 +48,27 @@ print_info() {
 
 show_usage() {
     cat << EOF
-YubiKey OTP Slot 2 Management
+YubiKey OTP Slot ${SLOT} Management
 
 USAGE:
     $(basename "$0") [COMMAND]
 
 COMMANDS:
-    configure   Configure OTP slot 2 with touch-required challenge-response
-    delete      Delete OTP slot 2 configuration
+    configure   Configure OTP Slot ${SLOT} with touch-required challenge-response
+    delete      Delete OTP Slot ${SLOT} configuration
     status      Show current OTP slot status
     help        Show this help message
 
 EXAMPLES:
     $(basename "$0") configure    # Set up touch-required verification
     $(basename "$0") status        # Check current configuration
-    $(basename "$0") delete        # Remove slot 2 configuration
+    $(basename "$0") delete        # Remove Slot ${SLOT} configuration
 
 NOTES:
-    - Slot 2 is used for YubiKey git enforcement
+    - Slot ${SLOT} is used for YubiKey igris enforcement (HMAC-SHA1)
     - Touch requirement ensures physical presence for verification
-    - Deleting slot 2 will disable tap verification (falls back to insecure mode)
+    - Deleting Slot ${SLOT} will disable tap verification (falls back to insecure mode)
+    - Override slot with IGRIS_OTP_SLOT env var or yubikey.slot in config
 
 EOF
 }
@@ -89,14 +100,14 @@ cmd_status() {
     ykman otp info
 
     echo ""
-    # Check if slot 2 is configured
-    if ykman otp info 2>/dev/null | grep -q "Slot 2: programmed"; then
-        print_success "Slot 2 is configured (tap-required verification available)"
+    # Check if configured slot is ready
+    if ykman otp info 2>/dev/null | grep -q "Slot ${SLOT}: programmed"; then
+        print_success "Slot ${SLOT} is configured (tap-required verification available)"
         echo ""
         print_info "Test verification:"
         echo "  \$TOMB_DIR/scripts/yubikey-verify.sh \"test\""
-    elif ykman otp info 2>/dev/null | grep -q "Slot 2: empty"; then
-        print_warning "Slot 2 is NOT configured"
+    elif ykman otp info 2>/dev/null | grep -q "Slot ${SLOT}: empty"; then
+        print_warning "Slot ${SLOT} is NOT configured"
         echo ""
         print_info "Configure with:"
         echo "  $(basename "$0") configure"
@@ -105,7 +116,7 @@ cmd_status() {
 }
 
 cmd_configure() {
-    print_header "YubiKey OTP Configuration for Touch-Required Verification"
+    print_header "YubiKey OTP Slot ${SLOT} Configuration (Touch-Required)"
 
     check_prerequisites
 
@@ -114,14 +125,14 @@ cmd_configure() {
     print_info "Detected: $YUBIKEY_INFO"
     echo ""
 
-    # Check current OTP slot 2 status
-    print_info "Checking OTP Slot 2 status..."
+    # Check current OTP slot status
+    print_info "Checking OTP Slot ${SLOT} status..."
     ykman otp info
     echo ""
 
-    # Check if slot 2 is already configured
-    if ykman otp info 2>/dev/null | grep -q "Slot 2: programmed"; then
-        print_warning "OTP Slot 2 is already programmed!"
+    # Check if slot is already configured
+    if ykman otp info 2>/dev/null | grep -q "Slot ${SLOT}: programmed"; then
+        print_warning "OTP Slot ${SLOT} is already programmed!"
         echo ""
         echo "Options:"
         echo "  1. Overwrite (will generate NEW credential - breaks existing uses)"
@@ -144,13 +155,13 @@ cmd_configure() {
         esac
     fi
 
-    # Configure slot 2 with challenge-response + touch requirement
+    # Configure slot with challenge-response + touch requirement
     echo ""
-    print_header "Configuring OTP Slot 2"
+    print_header "Configuring OTP Slot ${SLOT}"
 
     echo "This will:"
     echo "  • Generate a random secret key for challenge-response"
-    echo "  • Store it securely on your YubiKey (slot 2)"
+    echo "  • Store it securely on your YubiKey (Slot ${SLOT})"
     echo "  • Require physical touch for every verification"
     echo ""
     read -p "Proceed with configuration? (yes/no): " confirm
@@ -161,12 +172,12 @@ cmd_configure() {
     fi
 
     echo ""
-    print_info "Configuring OTP slot 2 with touch requirement..."
+    print_info "Configuring OTP Slot ${SLOT} with touch requirement..."
 
     # Run ykman otp chalresp with --generate and --touch flags
-    if ykman otp chalresp --generate --touch --force 2; then
+    if ykman otp chalresp --generate --touch --force "$SLOT"; then
         echo ""
-        print_success "OTP Slot 2 configured successfully!"
+        print_success "OTP Slot ${SLOT} configured successfully!"
         echo ""
         print_info "Configuration details:"
         echo "  • Type: Challenge-Response (HMAC-SHA1)"
@@ -234,17 +245,17 @@ cmd_configure() {
 }
 
 cmd_delete() {
-    print_header "Delete YubiKey OTP Slot 2 Configuration"
+    print_header "Delete YubiKey OTP Slot ${SLOT} Configuration"
 
     check_prerequisites
 
-    # Check if slot 2 is configured
-    if ykman otp info 2>/dev/null | grep -q "Slot 2: empty"; then
-        print_info "Slot 2 is already empty (nothing to delete)"
+    # Check if slot is configured
+    if ykman otp info 2>/dev/null | grep -q "Slot ${SLOT}: empty"; then
+        print_info "Slot ${SLOT} is already empty (nothing to delete)"
         exit 0
     fi
 
-    print_warning "This will DELETE the challenge-response credential from slot 2"
+    print_warning "This will DELETE the challenge-response credential from Slot ${SLOT}"
     echo ""
     echo "Impact:"
     echo "  • YubiKey tap verification will no longer work"
@@ -254,7 +265,7 @@ cmd_delete() {
     print_warning "This is a DESTRUCTIVE operation!"
     echo ""
 
-    read -p "Are you sure you want to delete slot 2? (yes/no): " confirm
+    read -p "Are you sure you want to delete Slot ${SLOT}? (yes/no): " confirm
 
     if [ "$confirm" != "yes" ]; then
         print_info "Deletion cancelled"
@@ -262,11 +273,11 @@ cmd_delete() {
     fi
 
     echo ""
-    print_info "Deleting OTP slot 2..."
+    print_info "Deleting OTP Slot ${SLOT}..."
 
-    if ykman otp delete --force 2; then
+    if ykman otp delete --force "$SLOT"; then
         echo ""
-        print_success "OTP Slot 2 deleted successfully"
+        print_success "OTP Slot ${SLOT} deleted successfully"
         echo ""
         print_info "Current status:"
         ykman otp info

--- a/scripts/yubikey-verify.sh
+++ b/scripts/yubikey-verify.sh
@@ -21,6 +21,31 @@ else
     YKMAN_BIN="ykman"  # Fallback to PATH
 fi
 
+# OTP slot for HMAC-SHA1 challenge-response (configurable)
+# Read from env var, then config file, default to 1
+if [ -z "${IGRIS_OTP_SLOT:-}" ] && [ -f "$CONFIG_FILE" ]; then
+    IGRIS_OTP_SLOT=$(grep -A 5 "^yubikey:" "$CONFIG_FILE" 2>/dev/null | grep "slot:" | head -1 | awk '{print $2}')
+fi
+SLOT="${IGRIS_OTP_SLOT:-1}"
+
+# Timeout wrapper — macOS USB HID requires --foreground to stay in same process group
+_timeout_cmd() {
+    local secs="$1"
+    shift
+    if command -v timeout &>/dev/null; then
+        # --foreground prevents process group creation (required for macOS USB HID)
+        timeout --foreground "${secs}s" "$@"
+        return $?
+    elif command -v gtimeout &>/dev/null; then
+        gtimeout --foreground "${secs}s" "$@"
+        return $?
+    else
+        # No timeout available — run directly (YubiKey has ~15s hardware timeout)
+        "$@"
+        return $?
+    fi
+}
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -172,6 +197,13 @@ play_audio_alert() {
         elif [[ "$OPERATION" =~ "workflow run" ]]; then
             cmd_action="workflow_run"
         fi
+    elif [[ "$OPERATION" =~ ^docker ]]; then
+        cmd_type="docker"
+        # Extract docker action (operation format: "docker container.exec [tap 1/2]")
+        local docker_op="${OPERATION#docker }"
+        docker_op="${docker_op%% \[*}"  # Strip "[tap N/N]" suffix
+        # Convert dotted notation to underscore for audio config lookup
+        cmd_action="${docker_op//./_}"
     fi
 
     # Check if modular audio is enabled
@@ -450,22 +482,22 @@ detect_yubikey() {
     return 0
 }
 
-# Verify OTP slot 2 is configured with touch requirement
+# Verify OTP slot is configured with touch requirement
 check_otp_touch_configured() {
     local otp_info
     if ! otp_info=$($YKMAN_BIN otp info 2>/dev/null); then
         return 1
     fi
 
-    # Check if slot 2 has touch requirement configured
+    # Check if configured slot has touch requirement configured
     # $YKMAN_BIN shows "configured" but doesn't explicitly show touch flag
     # We need to test with a challenge to verify touch behavior
-    if echo "$otp_info" | grep -q "Slot 2: empty"; then
+    if echo "$otp_info" | grep -q "Slot ${SLOT}: empty"; then
         return 1
     fi
 
-    # Extract slot 2 info line
-    local slot2_line=$(echo "$otp_info" | grep -A 1 "Slot 2:" | tail -1)
+    # Extract slot info line
+    local slot_line=$(echo "$otp_info" | grep -A 1 "Slot ${SLOT}:" | tail -1)
 
     # Check for touch indicators in the output
     # Note: $YKMAN_BIN doesn't always show touch flag explicitly
@@ -538,6 +570,11 @@ cleanup_verification_cache() {
 
 # Check if recent verification exists in cache
 check_verification_cache() {
+    # Allow callers to force cache bypass (used for dual-tap Docker ops)
+    if [ "${TOMB_VERIFICATION_CACHE_ENABLED:-}" = "false" ]; then
+        return 1
+    fi
+
     # Read cache settings from config
     local cache_enabled=$(grep -A 10 "cache:" "$CONFIG_FILE" 2>/dev/null | grep "enabled:" | head -1 | sed 's/#.*//' | awk '{print $2}')
     if [ "$cache_enabled" != "true" ]; then
@@ -624,25 +661,25 @@ cache_successful_verification() {
 verify_otp_touch() {
     print_info "Verifying with OTP challenge-response (requires physical tap)..."
 
-    # Check if OTP slot 2 is configured
+    # Check if OTP slot is configured
     local otp_info
     if ! otp_info=$($YKMAN_BIN otp info 2>/dev/null); then
         print_warning "OTP not configured on this YubiKey"
         return 1
     fi
 
-    # Check if slot 2 has a credential
-    if echo "$otp_info" | grep -q "Slot 2: empty"; then
-        print_warning "OTP Slot 2 is empty - needs configuration"
-        print_info "Run: $YKMAN_BIN otp chalresp --generate --touch 2"
+    # Check if slot has a credential
+    if echo "$otp_info" | grep -q "Slot ${SLOT}: empty"; then
+        print_warning "OTP Slot ${SLOT} is empty - needs configuration"
+        print_info "Run: $YKMAN_BIN otp chalresp --generate --touch ${SLOT}"
         return 1
     fi
 
-    # SECURITY: Verify slot 2 is configured for challenge-response
-    if ! echo "$otp_info" | grep -q "Slot 2:.*programmed"; then
-        if ! echo "$otp_info" | grep -A 1 "Slot 2:" | grep -q "configured\|programmed\|HMAC-SHA1"; then
-            print_warning "OTP Slot 2 not properly configured"
-            print_info "Run: $YKMAN_BIN otp chalresp --generate --touch 2"
+    # SECURITY: Verify slot is configured for challenge-response
+    if ! echo "$otp_info" | grep -q "Slot ${SLOT}:.*programmed"; then
+        if ! echo "$otp_info" | grep -A 1 "Slot ${SLOT}:" | grep -q "configured\|programmed\|HMAC-SHA1"; then
+            print_warning "OTP Slot ${SLOT} not properly configured"
+            print_info "Run: $YKMAN_BIN otp chalresp --generate --touch ${SLOT}"
             return 1
         fi
     fi
@@ -662,7 +699,7 @@ verify_otp_touch() {
     local start_time_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
 
     # Try the challenge-response
-    if response=$(timeout "${TIMEOUT_SECONDS}s" $YKMAN_BIN otp calculate 2 "$challenge" 2>&1); then
+    if response=$(_timeout_cmd "$TIMEOUT_SECONDS" $YKMAN_BIN otp calculate "$SLOT" "$challenge" 2>&1); then
         local end_time_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
         local elapsed=$(($(date +%s) - start_time))
         local elapsed_ms=$((end_time_ms - start_time_ms))
@@ -673,15 +710,15 @@ verify_otp_touch() {
         if [ "$elapsed_ms" -lt 800 ]; then
             play_state_audio "timing_violation"
             print_error "⚠️  SECURITY VIOLATION: Response too fast (${elapsed_ms}ms)!"
-            print_error "OTP Slot 2 is NOT configured to require physical touch"
+            print_error "OTP Slot ${SLOT} is NOT configured to require physical touch"
             print_error "This allows auto-acceptance without hardware verification"
             echo "" >&2
             print_info "FIX REQUIRED:" >&2
-            echo "  1. Reconfigure slot 2 WITH touch requirement:" >&2
+            echo "  1. Reconfigure Slot ${SLOT} WITH touch requirement:" >&2
             echo "     cd ${TOMB_DIR}" >&2
             echo "     ./scripts/yubikey-configure-otp.sh configure" >&2
             echo "  2. Verify touch is working:" >&2
-            echo "     ./scripts/yubikey-git-setup.sh test" >&2
+            echo "     ./scripts/hardware-git-setup.sh test" >&2
             log_verification "FAILURE" "NO-TOUCH-CONFIGURED" "$YUBIKEY_SERIAL"
             return 1
         fi
@@ -720,9 +757,9 @@ verify_otp() {
         return 1
     fi
 
-    # Check if slot 2 is configured for challenge-response
-    if ! echo "$otp_info" | grep -q "Slot 2:"; then
-        print_warning "OTP Slot 2 not configured for challenge-response"
+    # Check if slot is configured for challenge-response
+    if ! echo "$otp_info" | grep -q "Slot ${SLOT}:"; then
+        print_warning "OTP Slot ${SLOT} not configured for challenge-response"
         return 1
     fi
 
@@ -735,7 +772,7 @@ verify_otp() {
     local response
     local start_time_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
 
-    if response=$(timeout "$TIMEOUT_SECONDS" $YKMAN_BIN otp chalresp 2 "$challenge" 2>/dev/null); then
+    if response=$(_timeout_cmd "$TIMEOUT_SECONDS" $YKMAN_BIN otp chalresp "$SLOT" "$challenge" 2>/dev/null); then
         local end_time_ms=$(python3 -c 'import time; print(int(time.time() * 1000))')
         local elapsed_ms=$((end_time_ms - start_time_ms))
 
@@ -743,21 +780,21 @@ verify_otp() {
         if [ "$elapsed_ms" -lt 800 ]; then
             play_state_audio "timing_violation"
             print_error "⚠️  SECURITY VIOLATION: Response too fast (${elapsed_ms}ms)!"
-            print_error "OTP Slot 2 is NOT configured to require physical touch"
+            print_error "OTP Slot ${SLOT} is NOT configured to require physical touch"
             print_error "This allows auto-acceptance without hardware verification"
             echo "" >&2
             print_info "FIX REQUIRED:" >&2
-            echo "  1. Reconfigure slot 2 WITH touch requirement:" >&2
+            echo "  1. Reconfigure Slot ${SLOT} WITH touch requirement:" >&2
             echo "     cd ${TOMB_DIR}" >&2
             echo "     ./scripts/yubikey-configure-otp.sh configure" >&2
             echo "  2. Verify touch is working:" >&2
-            echo "     ./scripts/yubikey-git-setup.sh test" >&2
+            echo "     ./scripts/hardware-git-setup.sh test" >&2
             log_verification "FAILURE" "NO-TOUCH-CONFIGURED-FALLBACK" "$YUBIKEY_SERIAL"
             return 1
         fi
 
         print_success "YubiKey verified via OTP challenge-response! (${elapsed_ms}ms)"
-        print_warning "⚠️  Used OTP without guaranteed touch - consider configuring slot 2 with --touch"
+        print_warning "⚠️  Used OTP without guaranteed touch - consider configuring Slot ${SLOT} with --touch"
         log_verification "SUCCESS" "OTP" "$YUBIKEY_SERIAL"
         return 0
     else
@@ -825,7 +862,7 @@ main() {
     print_warning "OTP touch verification not available, trying OTP without touch..."
     if verify_otp; then
         cache_successful_verification
-        print_warning "⚠️  Used OTP without guaranteed touch - consider configuring slot 2 with --touch"
+        print_warning "⚠️  Used OTP without guaranteed touch - consider configuring Slot ${SLOT} with --touch"
         print_success "Verification successful! Proceeding with ${OPERATION}"
         play_state_audio "completion"
         exit 0
@@ -836,7 +873,7 @@ main() {
     print_error "YubiKey is connected but not properly configured"
     echo "" >&2
     print_info "Required configuration:" >&2
-    echo "  1. Configure OTP slot 2: ${TOMB_DIR}/scripts/yubikey-configure-otp.sh configure" >&2
+    echo "  1. Configure OTP Slot ${SLOT}: ${TOMB_DIR}/scripts/yubikey-configure-otp.sh configure" >&2
     echo "  2. Ensure tap within timeout (${TIMEOUT_SECONDS}s)" >&2
     echo "  3. Check YubiKey firmware supports OTP" >&2
     log_verification "FAILURE" "otp_not_configured" "$YUBIKEY_SERIAL"

--- a/src/igris/__init__.py
+++ b/src/igris/__init__.py
@@ -1,3 +1,3 @@
 """Igris v2 — YubiKey FIDO2 authentication service."""
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/src/igris/__init__.py
+++ b/src/igris/__init__.py
@@ -1,3 +1,3 @@
-"""Igris v2 — YubiKey FIDO2 authentication service."""
+"""Igris v3 — YubiKey-gated security enforcement."""
 
-__version__ = "2.1.0"
+__version__ = "3.0.0"

--- a/src/igris/api/auth.py
+++ b/src/igris/api/auth.py
@@ -9,7 +9,7 @@ from igris.core.fido2 import (
 )
 from igris.core.session import create_session
 from igris.db.connection import get_connection
-from igris.db.migrations import run_migrations
+from igris.api.utils import serialize_fido2_options
 from fido2.webauthn import AttestedCredentialData
 
 router = APIRouter(prefix="/auth/fido2", tags=["auth"])
@@ -51,7 +51,7 @@ async def auth_begin():
 
     return AuthBeginResponse(
         request_id=request_id,
-        options=_serialize_options(challenge.options),
+        options=serialize_fido2_options(challenge.options),
     )
 
 
@@ -117,21 +117,3 @@ def _find_serial_by_credential(credential_id: bytes) -> str | None:
             (credential_id,),
         ).fetchone()
     return row["serial"] if row else None
-
-
-def _serialize_options(options: dict) -> dict:
-    """Convert fido2 options to JSON-safe dict."""
-    import base64
-
-    def _convert(obj):
-        if isinstance(obj, bytes):
-            return base64.urlsafe_b64encode(obj).rstrip(b"=").decode()
-        if isinstance(obj, dict):
-            return {k: _convert(v) for k, v in obj.items()}
-        if isinstance(obj, (list, tuple)):
-            return [_convert(v) for v in obj]
-        if hasattr(obj, "__dict__"):
-            return {k: _convert(v) for k, v in vars(obj).items() if not k.startswith("_")}
-        return obj
-
-    return _convert(options)

--- a/src/igris/api/keys.py
+++ b/src/igris/api/keys.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from igris.core.fido2 import begin_registration, complete_registration
 from igris.db.connection import get_connection
+from igris.api.utils import serialize_fido2_options
 
 router = APIRouter(prefix="/keys", tags=["keys"])
 
@@ -66,7 +67,7 @@ async def register_begin(body: RegisterBeginRequest):
 
     return RegisterBeginResponse(
         request_id=request_id,
-        options=_serialize_options(challenge.options),
+        options=serialize_fido2_options(challenge.options),
     )
 
 
@@ -126,21 +127,3 @@ async def list_keys():
         )
         for row in rows
     ]
-
-
-def _serialize_options(options: dict) -> dict:
-    """Convert fido2 options to JSON-safe dict."""
-    import base64
-
-    def _convert(obj):
-        if isinstance(obj, bytes):
-            return base64.urlsafe_b64encode(obj).rstrip(b"=").decode()
-        if isinstance(obj, dict):
-            return {k: _convert(v) for k, v in obj.items()}
-        if isinstance(obj, (list, tuple)):
-            return [_convert(v) for v in obj]
-        if hasattr(obj, "__dict__"):
-            return {k: _convert(v) for k, v in vars(obj).items() if not k.startswith("_")}
-        return obj
-
-    return _convert(options)

--- a/src/igris/api/otp.py
+++ b/src/igris/api/otp.py
@@ -1,0 +1,74 @@
+"""OTP authentication endpoints for YubiKey long-tap / static password."""
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, field_validator
+
+from igris.core.otp import check_rate_limit, record_failure, register_otp, verify_otp
+from igris.core.session import create_session
+
+router = APIRouter(prefix="/auth/otp", tags=["otp"])
+
+
+class OTPVerifyRequest(BaseModel):
+    password: str
+
+    @field_validator("password")
+    @classmethod
+    def password_not_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("Password must not be empty")
+        return v
+
+
+class OTPVerifyResponse(BaseModel):
+    session_id: str
+    yubikey_serial: str
+    auth_method: str = "otp"
+
+
+class OTPRegisterRequest(BaseModel):
+    yubikey_serial: str
+    password: str
+
+    @field_validator("password")
+    @classmethod
+    def password_min_length(cls, v: str) -> str:
+        if len(v) < 12:
+            raise ValueError("Password must be at least 12 characters")
+        return v
+
+
+class OTPRegisterResponse(BaseModel):
+    yubikey_serial: str
+    credential_id: int
+
+
+@router.post("/verify", response_model=OTPVerifyResponse)
+async def otp_verify(body: OTPVerifyRequest, request: Request):
+    """Verify a YubiKey OTP / static password."""
+    client_ip = request.client.host if request.client else ""
+
+    if not check_rate_limit(client_ip):
+        raise HTTPException(status_code=429, detail="Too many failed attempts, try again later")
+
+    serial = verify_otp(body.password)
+    if serial is None:
+        record_failure(client_ip)
+        raise HTTPException(status_code=401, detail="Invalid OTP")
+
+    session_id = create_session(serial, ip_address=client_ip, auth_method="otp")
+    return OTPVerifyResponse(session_id=session_id, yubikey_serial=serial)
+
+
+@router.post("/register", response_model=OTPRegisterResponse)
+async def otp_register(body: OTPRegisterRequest):
+    """Register an OTP credential for a YubiKey."""
+    try:
+        credential_id = register_otp(body.yubikey_serial, body.password)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"YubiKey {body.yubikey_serial} not registered")
+
+    return OTPRegisterResponse(
+        yubikey_serial=body.yubikey_serial,
+        credential_id=credential_id,
+    )

--- a/src/igris/api/sessions.py
+++ b/src/igris/api/sessions.py
@@ -13,6 +13,7 @@ class SessionValidateResponse(BaseModel):
     yubikey_serial: str | None = None
     tier_level: str | None = None
     expires_at: str | None = None
+    auth_method: str | None = None
 
 
 class SessionRevokeResponse(BaseModel):
@@ -31,6 +32,7 @@ async def validate(session_id: str):
         yubikey_serial=result["yubikey_serial"],
         tier_level=result["tier_level"],
         expires_at=result["expires_at"],
+        auth_method=result.get("auth_method", "fido2"),
     )
 
 

--- a/src/igris/api/utils.py
+++ b/src/igris/api/utils.py
@@ -1,0 +1,28 @@
+"""Shared API utilities."""
+
+import base64
+
+
+def serialize_fido2_options(options: dict) -> dict:
+    """Convert fido2 options to JSON-safe dict.
+
+    Recursively converts bytes to base64url strings and dataclass-like
+    objects to dicts. Used by both auth and key registration endpoints.
+
+    Note: Challenge state is stored in-memory (module-level dicts in
+    auth.py and keys.py). This requires a single-worker deployment.
+    Multi-worker setups would need Redis or database-backed state.
+    """
+
+    def _convert(obj):
+        if isinstance(obj, bytes):
+            return base64.urlsafe_b64encode(obj).rstrip(b"=").decode()
+        if isinstance(obj, dict):
+            return {k: _convert(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [_convert(v) for v in obj]
+        if hasattr(obj, "__dict__"):
+            return {k: _convert(v) for k, v in vars(obj).items() if not k.startswith("_")}
+        return obj
+
+    return _convert(options)

--- a/src/igris/cli.py
+++ b/src/igris/cli.py
@@ -1,0 +1,276 @@
+"""igris CLI — unified command for security enforcement management."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import typer
+
+app = typer.Typer(
+    name="igris",
+    help="YubiKey-gated security enforcement for git, Docker, and shell operations.",
+    no_args_is_help=True,
+)
+
+
+def _repo_root() -> Path:
+    """Resolve the igris repository root."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _is_vm() -> bool:
+    """Detect VM environment."""
+    return os.environ.get("USER", "").endswith("vm")
+
+
+def _shell_config() -> Path:
+    """Detect the user's shell config file."""
+    if Path.home().joinpath(".zshrc").exists():
+        return Path.home() / ".zshrc"
+    if sys.platform == "darwin":
+        return Path.home() / ".bash_profile"
+    return Path.home() / ".bashrc"
+
+
+@app.command()
+def status() -> None:
+    """Show enforcement status (Docker, git, environment)."""
+    shell_config = _shell_config()
+    config_text = shell_config.read_text() if shell_config.exists() else ""
+
+    typer.echo("=== igris enforcement status ===\n")
+
+    # Environment
+    env = "VM (autonomous)" if _is_vm() else "Main machine (co-pairing)"
+    typer.echo(f"Environment:  {env}")
+    typer.echo(f"User:         {os.environ.get('USER', 'unknown')}")
+
+    # Master enforcement
+    enabled = os.environ.get("TOMB_YUBIKEY_ENABLED", "true")
+    if enabled == "true" or "TOMB_YUBIKEY_ENABLED=true" in config_text:
+        typer.echo("Enforcement:  ENABLED")
+    else:
+        typer.echo("Enforcement:  DISABLED")
+
+    typer.echo("")
+
+    # Git wrapper
+    if "git-yubikey-wrapper" in config_text or "YubiKey Git Enforcement" in config_text:
+        typer.echo("git wrapper:  installed")
+    else:
+        typer.echo("git wrapper:  not installed")
+
+    # gh wrapper
+    if "gh-yubikey-wrapper" in config_text:
+        typer.echo("gh wrapper:   installed")
+    else:
+        typer.echo("gh wrapper:   not installed")
+
+    # rm wrapper
+    if "Dangerous rm Protection" in config_text:
+        typer.echo("rm protect:   installed")
+    else:
+        typer.echo("rm protect:   not installed")
+
+    # Docker wrapper
+    if "Docker Operation Gating" in config_text:
+        docker_enabled = os.environ.get("IGRIS_DOCKER_ENABLED", "true")
+        typer.echo(f"Docker:       installed (enabled={docker_enabled})")
+        policy_path = Path.home() / ".config" / "igris" / "policy.yaml"
+        if policy_path.exists():
+            typer.echo(f"              policy: {policy_path}")
+    else:
+        typer.echo("Docker:       not installed")
+
+    typer.echo("")
+
+    # YubiKey slot config
+    repo_root = _repo_root()
+    config_file = repo_root / "configs" / "yubikey-enforcement.yml"
+    if config_file.exists():
+        import yaml
+
+        with open(config_file) as f:
+            cfg = yaml.safe_load(f)
+        slot = os.environ.get("IGRIS_OTP_SLOT")
+        if not slot and isinstance(cfg, dict):
+            yk = cfg.get("yubikey", {})
+            slot = str(yk.get("slot", 1)) if isinstance(yk, dict) else "1"
+        typer.echo(f"OTP Slot:     {slot or '1'}")
+
+    # Recent audit entries
+    audit_path = Path.home() / ".cache" / "igris" / "audit.jsonl"
+    if audit_path.exists():
+        lines = audit_path.read_text().strip().splitlines()
+        recent = lines[-3:] if len(lines) >= 3 else lines
+        if recent:
+            typer.echo("\nRecent Docker audit:")
+            for line in recent:
+                try:
+                    entry = json.loads(line)
+                    ts = entry.get("timestamp", "?")[:19]
+                    op = entry.get("operation", "?")
+                    outcome = entry.get("outcome", "?")
+                    level = entry.get("auth_level", "?")
+                    typer.echo(f"  {ts}  {op:30s}  {level:15s}  {outcome}")
+                except json.JSONDecodeError:
+                    pass
+
+
+@app.command()
+def docker(
+    args: list[str] = typer.Argument(None, help="Docker command arguments"),
+) -> None:
+    """Docker passthrough with policy gating (same logic as shell wrapper)."""
+    from igris.docker.audit import log_entry
+    from igris.docker.policy import AuthLevel, PolicyConfig, classify_docker_command
+
+    if not args:
+        typer.echo("Usage: igris docker <docker-args>")
+        raise typer.Exit(1)
+
+    # VM bypass
+    if _is_vm():
+        _exec_docker(args)
+
+    # Enforcement disabled
+    if os.environ.get("IGRIS_DOCKER_ENABLED", "true") == "false":
+        _exec_docker(args)
+    if os.environ.get("TOMB_YUBIKEY_ENABLED", "true") == "false":
+        _exec_docker(args)
+
+    policy_path = Path.home() / ".config" / "igris" / "policy.yaml"
+    policy = PolicyConfig.load(policy_path)
+    operation, level = classify_docker_command(args, policy)
+
+    if level == AuthLevel.AUTO_APPROVE:
+        log_entry(operation, level.value, "approved", f"docker {' '.join(args)}")
+        _exec_docker(args)
+
+    repo_root = _repo_root()
+    verify_script = repo_root / "scripts" / "hardware-verify.sh"
+
+    if level == AuthLevel.SINGLE_TAP:
+        if verify_script.exists():
+            result = subprocess.run(
+                [str(verify_script), f"docker {operation}"],
+                check=False,
+            )
+            if result.returncode != 0:
+                log_entry(operation, level.value, "denied", f"docker {' '.join(args)}")
+                typer.echo("Hardware verification failed. Docker operation aborted.", err=True)
+                raise typer.Exit(1)
+        log_entry(operation, level.value, "approved", f"docker {' '.join(args)}")
+        _exec_docker(args)
+
+    if level == AuthLevel.DUAL_TAP:
+        typer.echo(f"Dual-tap required for: docker {operation}", err=True)
+        if verify_script.exists():
+            # First tap
+            typer.echo("First YubiKey tap...", err=True)
+            r1 = subprocess.run(
+                [str(verify_script), f"docker {operation} [tap 1/2]"],
+                check=False,
+            )
+            if r1.returncode != 0:
+                log_entry(operation, level.value, "denied", f"docker {' '.join(args)}")
+                raise typer.Exit(1)
+
+            # Second tap (cache disabled)
+            import time
+
+            time.sleep(1)
+            typer.echo("Second YubiKey tap required (confirmation)...", err=True)
+            env = os.environ.copy()
+            env["TOMB_VERIFICATION_CACHE_ENABLED"] = "false"
+            r2 = subprocess.run(
+                [str(verify_script), f"docker {operation} [tap 2/2]"],
+                env=env,
+                check=False,
+            )
+            if r2.returncode != 0:
+                log_entry(operation, level.value, "denied", f"docker {' '.join(args)}")
+                raise typer.Exit(1)
+
+        log_entry(operation, level.value, "approved", f"docker {' '.join(args)}")
+        _exec_docker(args)
+
+
+def _exec_docker(args: list[str]) -> None:
+    """Execute the real docker binary (does not return)."""
+    docker_bin = os.environ.get("IGRIS_DOCKER_BINARY")
+    if not docker_bin:
+        import shutil
+
+        docker_bin = shutil.which("docker")
+    if not docker_bin:
+        typer.echo("Docker binary not found", err=True)
+        raise typer.Exit(1)
+    os.execvp(docker_bin, [docker_bin, *args])
+
+
+@app.command()
+def audit(
+    tail: int = typer.Option(10, "--tail", "-n", help="Number of entries to show"),
+) -> None:
+    """View recent Docker audit entries."""
+    audit_path = Path.home() / ".cache" / "igris" / "audit.jsonl"
+    if not audit_path.exists():
+        typer.echo("No audit entries found.")
+        raise typer.Exit(0)
+
+    lines = audit_path.read_text().strip().splitlines()
+    recent = lines[-tail:] if len(lines) > tail else lines
+
+    typer.echo(f"{'Timestamp':<22} {'Operation':<30} {'Level':<15} {'Outcome':<10} {'Command'}")
+    typer.echo("-" * 100)
+    for line in recent:
+        try:
+            entry = json.loads(line)
+            ts = entry.get("timestamp", "?")[:19]
+            op = entry.get("operation", "?")
+            level = entry.get("auth_level", "?")
+            outcome = entry.get("outcome", "?")
+            cmd = entry.get("raw_command", "?")[:40]
+            typer.echo(f"{ts:<22} {op:<30} {level:<15} {outcome:<10} {cmd}")
+        except json.JSONDecodeError:
+            pass
+
+
+@app.command()
+def policy(
+    show: bool = typer.Option(True, "--show", help="Display current policy"),
+) -> None:
+    """Display current Docker policy configuration."""
+    policy_path = Path.home() / ".config" / "igris" / "policy.yaml"
+
+    if not policy_path.exists():
+        typer.echo("No custom policy found. Using embedded defaults.")
+        typer.echo(f"Expected location: {policy_path}")
+        typer.echo("")
+        _show_default_policy()
+        return
+
+    if show:
+        typer.echo(f"Policy file: {policy_path}\n")
+        typer.echo(policy_path.read_text())
+
+
+def _show_default_policy() -> None:
+    """Display the embedded default policy."""
+    from igris.docker.policy import DEFAULT_POLICY
+
+    typer.echo("=== Embedded Default Policy ===\n")
+    for level_name, ops in DEFAULT_POLICY.items():
+        typer.echo(f"[{level_name}]")
+        for op in ops:
+            typer.echo(f"  - {op}")
+        typer.echo("")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/igris/config.py
+++ b/src/igris/config.py
@@ -24,6 +24,11 @@ class Settings(BaseSettings):
     # Sessions
     session_ttl_seconds: int = 3600  # 1 hour default
 
+    # OTP (long-tap / static password)
+    otp_session_ttl_seconds: int = 1800  # 30 min (shorter than FIDO2)
+    otp_max_attempts: int = 5
+    otp_lockout_seconds: int = 600  # 10 min lockout
+
     # Network security — comma-separated CIDR subnets
     allowed_subnets: str = "127.0.0.0/8"
 

--- a/src/igris/core/otp.py
+++ b/src/igris/core/otp.py
@@ -1,0 +1,110 @@
+"""OTP password hashing, verification, and rate limiting."""
+
+import logging
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+import igris.config as _config
+from igris.db.connection import get_connection
+
+logger = logging.getLogger(__name__)
+
+_hasher = PasswordHasher()
+
+# In-memory rate limiting (consistent with existing challenge state pattern).
+# Note: resets on process restart; single-worker only.
+_failed_attempts: dict[str, list[float]] = defaultdict(list)
+
+
+def hash_password(password: str) -> str:
+    """Hash a password using Argon2id."""
+    return _hasher.hash(password)
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    """Verify a password against an Argon2id hash."""
+    try:
+        return _hasher.verify(password_hash, password)
+    except VerifyMismatchError:
+        return False
+
+
+def check_rate_limit(ip: str) -> bool:
+    """Return True if the IP is allowed to attempt, False if locked out."""
+    now = time.monotonic()
+    window = _config.settings.otp_lockout_seconds
+    max_attempts = _config.settings.otp_max_attempts
+
+    # Prune old entries outside the window
+    _failed_attempts[ip] = [t for t in _failed_attempts[ip] if now - t < window]
+
+    return len(_failed_attempts[ip]) < max_attempts
+
+
+def record_failure(ip: str) -> None:
+    """Record a failed OTP attempt for rate limiting."""
+    _failed_attempts[ip].append(time.monotonic())
+
+
+def register_otp(serial: str, password: str) -> int:
+    """Store an OTP credential for a YubiKey serial.
+
+    Deactivates any previous OTP credentials for the same serial.
+    Returns the new credential ID.
+    """
+    password_hash = hash_password(password)
+    now = datetime.now(timezone.utc).isoformat()
+
+    with get_connection() as conn:
+        # Verify the yubikey exists
+        row = conn.execute(
+            "SELECT serial FROM yubikeys WHERE serial = ?", (serial,)
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"YubiKey serial {serial} not registered")
+
+        # Deactivate previous OTP credentials for this serial
+        conn.execute(
+            "UPDATE otp_credentials SET is_active = 0 WHERE yubikey_serial = ?",
+            (serial,),
+        )
+
+        # Insert new credential
+        cursor = conn.execute(
+            """INSERT INTO otp_credentials
+               (yubikey_serial, password_hash, hash_algorithm, created_at, is_active)
+               VALUES (?, ?, 'argon2id', ?, 1)""",
+            (serial, password_hash, now),
+        )
+        credential_id = cursor.lastrowid
+
+        # Audit
+        conn.execute(
+            """INSERT INTO audit_log (timestamp, event_type, yubikey_serial, ip_address, details)
+               VALUES (?, 'otp_registered', ?, '', '{}')""",
+            (now, serial),
+        )
+
+    logger.info("OTP credential registered for serial=%s (id=%d)", serial, credential_id)
+    return credential_id
+
+
+def verify_otp(password: str) -> str | None:
+    """Check password against all active OTP credentials.
+
+    Returns the matching YubiKey serial, or None if no match.
+    """
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT yubikey_serial, password_hash FROM otp_credentials WHERE is_active = 1"
+        ).fetchall()
+
+    for row in rows:
+        if verify_password(password, row["password_hash"]):
+            return row["yubikey_serial"]
+
+    return None

--- a/src/igris/core/session.py
+++ b/src/igris/core/session.py
@@ -11,21 +11,27 @@ from igris.db.connection import get_connection
 logger = logging.getLogger(__name__)
 
 
-def create_session(yubikey_serial: str, ip_address: str = "", tier: str = "standard") -> str:
+def create_session(yubikey_serial: str, ip_address: str = "", tier: str = "standard", auth_method: str = "fido2") -> str:
     """Create a new authenticated session. Returns session_id."""
     session_id = secrets.token_urlsafe(32)
     now = datetime.now(timezone.utc)
-    expires = now + timedelta(seconds=_config.settings.session_ttl_seconds)
+
+    # Dynamic TTL based on auth method
+    if auth_method == "otp":
+        ttl = _config.settings.otp_session_ttl_seconds
+    else:
+        ttl = _config.settings.session_ttl_seconds
+    expires = now + timedelta(seconds=ttl)
 
     with get_connection() as conn:
         conn.execute(
-            """INSERT INTO sessions (session_id, yubikey_serial, created_at, expires_at, tier_level, ip_address)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (session_id, yubikey_serial, now.isoformat(), expires.isoformat(), tier, ip_address),
+            """INSERT INTO sessions (session_id, yubikey_serial, created_at, expires_at, tier_level, ip_address, auth_method)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (session_id, yubikey_serial, now.isoformat(), expires.isoformat(), tier, ip_address, auth_method),
         )
-        _audit(conn, "session_created", yubikey_serial, ip_address, {"session_id": session_id})
+        _audit(conn, "session_created", yubikey_serial, ip_address, {"session_id": session_id, "auth_method": auth_method})
 
-    logger.info("Session created: %s for serial=%s", session_id[:8], yubikey_serial)
+    logger.info("Session created: %s for serial=%s (auth=%s)", session_id[:8], yubikey_serial, auth_method)
     return session_id
 
 

--- a/src/igris/db/migrations.py
+++ b/src/igris/db/migrations.py
@@ -5,7 +5,7 @@ import sqlite3
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 MIGRATIONS: dict[int, list[str]] = {
     1: [
@@ -58,6 +58,26 @@ MIGRATIONS: dict[int, list[str]] = {
         """
         CREATE INDEX IF NOT EXISTS idx_audit_event_type
         ON audit_log(event_type)
+        """,
+    ],
+    2: [
+        """
+        CREATE TABLE IF NOT EXISTS otp_credentials (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            yubikey_serial TEXT NOT NULL,
+            password_hash TEXT NOT NULL,
+            hash_algorithm TEXT NOT NULL DEFAULT 'argon2id',
+            created_at TEXT NOT NULL,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY (yubikey_serial) REFERENCES yubikeys(serial)
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_otp_creds_serial
+        ON otp_credentials(yubikey_serial)
+        """,
+        """
+        ALTER TABLE sessions ADD COLUMN auth_method TEXT NOT NULL DEFAULT 'fido2'
         """,
     ],
 }

--- a/src/igris/db/models.py
+++ b/src/igris/db/models.py
@@ -28,6 +28,7 @@ class Session:
     expires_at: datetime = field(default_factory=_utcnow)
     tier_level: str = "standard"
     ip_address: str = ""
+    auth_method: str = "fido2"
 
 
 @dataclass
@@ -38,3 +39,13 @@ class AuditEntry:
     yubikey_serial: str = ""
     ip_address: str = ""
     details: str = ""  # JSON string
+
+
+@dataclass
+class OTPCredential:
+    id: int | None = None
+    yubikey_serial: str = ""
+    password_hash: str = ""
+    hash_algorithm: str = "argon2id"
+    created_at: datetime = field(default_factory=_utcnow)
+    is_active: bool = True

--- a/src/igris/docker/__init__.py
+++ b/src/igris/docker/__init__.py
@@ -1,0 +1,1 @@
+"""Docker operation gating for igris."""

--- a/src/igris/docker/audit.py
+++ b/src/igris/docker/audit.py
@@ -1,0 +1,45 @@
+"""JSONL audit logger for Docker operations."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _mask_serial(serial: str) -> str:
+    """Mask YubiKey serial, keeping last 2 digits."""
+    if not serial or serial in ("unknown", "n/a"):
+        return serial
+    return f"******{serial[-2:]}"
+
+
+def log_entry(
+    operation: str,
+    auth_level: str,
+    outcome: str,
+    raw_command: str,
+    serial: str = "unknown",
+    audit_path: Path | None = None,
+) -> None:
+    """Append a JSONL audit entry."""
+    if audit_path is None:
+        audit_path = Path.home() / ".cache" / "igris" / "audit.jsonl"
+
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "operation": operation,
+        "auth_level": auth_level,
+        "outcome": outcome,
+        "raw_command": raw_command,
+        "user": os.environ.get("USER", "unknown"),
+        "hostname": socket.gethostname(),
+        "serial": _mask_serial(serial),
+    }
+
+    with open(audit_path, "a") as f:
+        f.write(json.dumps(entry, separators=(",", ":")) + "\n")

--- a/src/igris/docker/policy.py
+++ b/src/igris/docker/policy.py
@@ -1,0 +1,260 @@
+"""Docker operation policy engine for igris.
+
+Classifies Docker CLI commands into auth levels:
+- auto_approve: read-only operations, no YubiKey needed
+- single_tap: state-changing operations, one YubiKey tap
+- dual_tap: destructive operations, two YubiKey taps
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+class AuthLevel(str, Enum):
+    AUTO_APPROVE = "auto_approve"
+    SINGLE_TAP = "single_tap"
+    DUAL_TAP = "dual_tap"
+
+
+# Docker CLI aliases → canonical subcommand mapping
+_DOCKER_ALIASES: dict[str, str] = {
+    "ps": "container.list",
+    "run": "container.run",
+    "exec": "container.exec",
+    "rm": "container.rm",
+    "kill": "container.kill",
+    "stop": "container.stop",
+    "start": "container.start",
+    "restart": "container.restart",
+    "logs": "container.logs",
+    "inspect": "container.inspect",
+    "create": "container.create",
+    "attach": "container.attach",
+    "wait": "container.wait",
+    "top": "container.top",
+    "stats": "container.stats",
+    "diff": "container.diff",
+    "cp": "container.cp",
+    "commit": "container.commit",
+    "export": "container.export",
+    "rename": "container.rename",
+    "update": "container.update",
+    "port": "container.port",
+    "pause": "container.pause",
+    "unpause": "container.unpause",
+    "pull": "image.pull",
+    "push": "image.push",
+    "build": "image.build",
+    "images": "image.list",
+    "rmi": "image.rm",
+    "tag": "image.tag",
+    "save": "image.save",
+    "load": "image.load",
+    "history": "image.history",
+    "login": "login",
+    "logout": "logout",
+    "info": "info",
+    "version": "version",
+    "events": "events",
+    "search": "search",
+}
+
+# Default policy (embedded fallback)
+DEFAULT_POLICY: dict[str, list[str]] = {
+    "auto_approve": [
+        "container.logs",
+        "container.list",
+        "container.inspect",
+        "container.top",
+        "container.stats",
+        "container.diff",
+        "container.port",
+        "container.wait",
+        "image.list",
+        "image.inspect",
+        "image.history",
+        "network.list",
+        "network.inspect",
+        "volume.list",
+        "volume.inspect",
+        "compose.ps",
+        "compose.logs",
+        "compose.config",
+        "info",
+        "version",
+        "events",
+        "search",
+    ],
+    "single_tap": [
+        "container.start",
+        "container.stop",
+        "container.restart",
+        "container.create",
+        "container.run",
+        "container.pause",
+        "container.unpause",
+        "container.rename",
+        "container.update",
+        "container.cp",
+        "container.commit",
+        "container.export",
+        "container.attach",
+        "image.pull",
+        "image.build",
+        "image.tag",
+        "image.save",
+        "image.load",
+        "image.push",
+        "network.create",
+        "network.connect",
+        "network.disconnect",
+        "volume.create",
+        "compose.up",
+        "compose.down",
+        "compose.restart",
+        "compose.build",
+        "compose.pull",
+        "compose.start",
+        "compose.stop",
+        "compose.create",
+        "login",
+        "logout",
+    ],
+    "dual_tap": [
+        "container.exec",
+        "container.rm",
+        "container.kill",
+        "image.rm",
+        "volume.rm",
+        "network.rm",
+        "compose.rm",
+        "system.prune",
+        "builder.prune",
+        "image.prune",
+        "container.prune",
+        "network.prune",
+        "volume.prune",
+    ],
+}
+
+
+@dataclass
+class PolicyConfig:
+    """Loaded policy configuration."""
+
+    operations: dict[str, AuthLevel] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, policy_path: Optional[Path] = None) -> PolicyConfig:
+        """Load policy from YAML file, falling back to embedded defaults."""
+        config = cls()
+
+        # Try loading from file
+        raw: dict[str, list[str]] | None = None
+        if policy_path and policy_path.exists():
+            with open(policy_path) as f:
+                data = yaml.safe_load(f)
+                if isinstance(data, dict) and "policy" in data:
+                    raw = data["policy"]
+
+        if raw is None:
+            raw = DEFAULT_POLICY
+
+        # Build operation → auth_level mapping
+        for level_name, ops in raw.items():
+            try:
+                level = AuthLevel(level_name)
+            except ValueError:
+                continue
+            for op in ops:
+                config.operations[op] = level
+
+        return config
+
+    def classify(self, operation: str) -> AuthLevel:
+        """Return the auth level for a dotted operation name."""
+        if operation in self.operations:
+            return self.operations[operation]
+        # Unknown operations default to single_tap (safe)
+        return AuthLevel.SINGLE_TAP
+
+
+def parse_docker_args(args: list[str]) -> str:
+    """Parse Docker CLI arguments into a dotted operation name.
+
+    Examples:
+        ["ps"]                    → "container.list"
+        ["exec", "c1", "bash"]    → "container.exec"
+        ["compose", "up", "-d"]   → "compose.up"
+        ["container", "rm", "c1"] → "container.rm"
+        ["system", "prune"]       → "system.prune"
+        ["image", "ls"]           → "image.list"
+    """
+    if not args:
+        return "unknown"
+
+    # Skip global flags (e.g. --host, -H, --tls, --context)
+    idx = 0
+    while idx < len(args) and args[idx].startswith("-"):
+        # Flags that take a value
+        if args[idx] in ("-H", "--host", "--context", "--config", "--log-level", "-l"):
+            idx += 2
+        else:
+            idx += 1
+
+    remaining = args[idx:]
+    if not remaining:
+        return "unknown"
+
+    cmd = remaining[0]
+
+    # Handle docker compose
+    if cmd in ("compose", "docker-compose"):
+        if len(remaining) < 2:
+            return "compose.unknown"
+        subcmd = remaining[1]
+        # Normalize aliases
+        if subcmd in ("ls", "list"):
+            subcmd = "ps"
+        return f"compose.{subcmd}"
+
+    # Handle top-level management commands (docker container, docker image, etc.)
+    management_commands = {
+        "container", "image", "network", "volume", "system", "builder",
+        "manifest", "trust", "plugin", "config", "secret", "service",
+        "stack", "node", "swarm", "context",
+    }
+    if cmd in management_commands:
+        if len(remaining) < 2:
+            return f"{cmd}.unknown"
+        subcmd = remaining[1]
+        # Normalize list aliases
+        if subcmd in ("ls", "list"):
+            subcmd = "list"
+        if subcmd == "prune":
+            return f"{cmd}.prune"
+        return f"{cmd}.{subcmd}"
+
+    # Handle top-level aliases (docker ps → container.list, etc.)
+    if cmd in _DOCKER_ALIASES:
+        return _DOCKER_ALIASES[cmd]
+
+    # Unknown top-level command
+    return f"{cmd}.unknown"
+
+
+def classify_docker_command(
+    args: list[str],
+    policy: Optional[PolicyConfig] = None,
+) -> tuple[str, AuthLevel]:
+    """Classify a Docker command and return (operation, auth_level)."""
+    if policy is None:
+        policy = PolicyConfig.load()
+    operation = parse_docker_args(args)
+    return operation, policy.classify(operation)

--- a/src/igris/main.py
+++ b/src/igris/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from igris import __version__
 from igris.api.auth import router as auth_router
 from igris.api.audit import router as audit_router
+from igris.api.otp import router as otp_router
 from igris.api.keys import router as keys_router
 from igris.api.sessions import router as sessions_router
 from igris.db.connection import get_connection
@@ -43,6 +44,7 @@ app.add_middleware(SubnetFilterMiddleware)
 
 # Routers
 app.include_router(auth_router)
+app.include_router(otp_router)
 app.include_router(keys_router)
 app.include_router(sessions_router)
 app.include_router(audit_router)

--- a/tests/test_docker_audit.py
+++ b/tests/test_docker_audit.py
@@ -1,0 +1,69 @@
+"""Tests for Docker audit logger."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from igris.docker.audit import _mask_serial, log_entry
+
+
+class TestMaskSerial:
+    def test_masks_serial(self):
+        assert _mask_serial("12345678") == "******78"
+
+    def test_short_serial(self):
+        assert _mask_serial("12") == "******12"
+
+    def test_unknown_passthrough(self):
+        assert _mask_serial("unknown") == "unknown"
+        assert _mask_serial("n/a") == "n/a"
+
+    def test_empty_passthrough(self):
+        assert _mask_serial("") == ""
+
+
+class TestLogEntry:
+    def test_creates_jsonl_entry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_path = Path(tmpdir) / "audit.jsonl"
+
+            log_entry(
+                operation="container.exec",
+                auth_level="dual_tap",
+                outcome="approved",
+                raw_command="docker exec c1 bash",
+                serial="12345678",
+                audit_path=audit_path,
+            )
+
+            assert audit_path.exists()
+            lines = audit_path.read_text().strip().splitlines()
+            assert len(lines) == 1
+
+            entry = json.loads(lines[0])
+            assert entry["operation"] == "container.exec"
+            assert entry["auth_level"] == "dual_tap"
+            assert entry["outcome"] == "approved"
+            assert entry["raw_command"] == "docker exec c1 bash"
+            assert entry["serial"] == "******78"
+            assert "timestamp" in entry
+            assert "user" in entry
+            assert "hostname" in entry
+
+    def test_appends_multiple_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_path = Path(tmpdir) / "audit.jsonl"
+
+            log_entry("container.rm", "dual_tap", "denied", "docker rm c1", audit_path=audit_path)
+            log_entry("container.list", "auto_approve", "approved", "docker ps", audit_path=audit_path)
+
+            lines = audit_path.read_text().strip().splitlines()
+            assert len(lines) == 2
+
+    def test_creates_parent_directories(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_path = Path(tmpdir) / "deep" / "nested" / "audit.jsonl"
+
+            log_entry("info", "auto_approve", "approved", "docker info", audit_path=audit_path)
+
+            assert audit_path.exists()

--- a/tests/test_docker_policy.py
+++ b/tests/test_docker_policy.py
@@ -1,0 +1,172 @@
+"""Tests for Docker operation policy engine."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from igris.docker.policy import (
+    AuthLevel,
+    PolicyConfig,
+    classify_docker_command,
+    parse_docker_args,
+)
+
+
+class TestParseDockerArgs:
+    """Test Docker CLI argument parsing into dotted operation names."""
+
+    def test_top_level_aliases(self):
+        assert parse_docker_args(["ps"]) == "container.list"
+        assert parse_docker_args(["run", "nginx"]) == "container.run"
+        assert parse_docker_args(["exec", "c1", "bash"]) == "container.exec"
+        assert parse_docker_args(["rm", "c1"]) == "container.rm"
+        assert parse_docker_args(["kill", "c1"]) == "container.kill"
+        assert parse_docker_args(["logs", "c1"]) == "container.logs"
+        assert parse_docker_args(["inspect", "c1"]) == "container.inspect"
+        assert parse_docker_args(["pull", "nginx"]) == "image.pull"
+        assert parse_docker_args(["push", "myimg"]) == "image.push"
+        assert parse_docker_args(["build", "."]) == "image.build"
+        assert parse_docker_args(["images"]) == "image.list"
+        assert parse_docker_args(["rmi", "img"]) == "image.rm"
+        assert parse_docker_args(["info"]) == "info"
+        assert parse_docker_args(["version"]) == "version"
+
+    def test_management_commands(self):
+        assert parse_docker_args(["container", "rm", "c1"]) == "container.rm"
+        assert parse_docker_args(["container", "ls"]) == "container.list"
+        assert parse_docker_args(["container", "list"]) == "container.list"
+        assert parse_docker_args(["image", "ls"]) == "image.list"
+        assert parse_docker_args(["image", "rm", "img"]) == "image.rm"
+        assert parse_docker_args(["network", "ls"]) == "network.list"
+        assert parse_docker_args(["network", "rm", "net"]) == "network.rm"
+        assert parse_docker_args(["volume", "ls"]) == "volume.list"
+        assert parse_docker_args(["volume", "rm", "vol"]) == "volume.rm"
+        assert parse_docker_args(["system", "prune"]) == "system.prune"
+        assert parse_docker_args(["builder", "prune"]) == "builder.prune"
+
+    def test_compose_commands(self):
+        assert parse_docker_args(["compose", "up", "-d"]) == "compose.up"
+        assert parse_docker_args(["compose", "down"]) == "compose.down"
+        assert parse_docker_args(["compose", "ps"]) == "compose.ps"
+        assert parse_docker_args(["compose", "logs"]) == "compose.logs"
+        assert parse_docker_args(["compose", "rm"]) == "compose.rm"
+        assert parse_docker_args(["compose", "build"]) == "compose.build"
+        assert parse_docker_args(["compose", "config"]) == "compose.config"
+        assert parse_docker_args(["compose", "restart"]) == "compose.restart"
+        assert parse_docker_args(["compose", "pull"]) == "compose.pull"
+
+    def test_global_flags_skipped(self):
+        assert parse_docker_args(["-H", "tcp://host:2375", "ps"]) == "container.list"
+        assert parse_docker_args(["--host", "tcp://host:2375", "rm", "c1"]) == "container.rm"
+        assert parse_docker_args(["--context", "mainmac", "exec", "c1", "sh"]) == "container.exec"
+
+    def test_empty_args(self):
+        assert parse_docker_args([]) == "unknown"
+
+    def test_unknown_command(self):
+        result = parse_docker_args(["somethingweird"])
+        assert result == "somethingweird.unknown"
+
+
+class TestPolicyConfig:
+    """Test policy loading and classification."""
+
+    def test_default_policy_classifies_read_ops(self):
+        policy = PolicyConfig.load()
+        assert policy.classify("container.logs") == AuthLevel.AUTO_APPROVE
+        assert policy.classify("container.list") == AuthLevel.AUTO_APPROVE
+        assert policy.classify("image.list") == AuthLevel.AUTO_APPROVE
+        assert policy.classify("info") == AuthLevel.AUTO_APPROVE
+        assert policy.classify("version") == AuthLevel.AUTO_APPROVE
+        assert policy.classify("compose.ps") == AuthLevel.AUTO_APPROVE
+
+    def test_default_policy_classifies_write_ops(self):
+        policy = PolicyConfig.load()
+        assert policy.classify("container.start") == AuthLevel.SINGLE_TAP
+        assert policy.classify("container.stop") == AuthLevel.SINGLE_TAP
+        assert policy.classify("container.run") == AuthLevel.SINGLE_TAP
+        assert policy.classify("image.pull") == AuthLevel.SINGLE_TAP
+        assert policy.classify("image.build") == AuthLevel.SINGLE_TAP
+        assert policy.classify("compose.up") == AuthLevel.SINGLE_TAP
+        assert policy.classify("compose.down") == AuthLevel.SINGLE_TAP
+
+    def test_default_policy_classifies_destructive_ops(self):
+        policy = PolicyConfig.load()
+        assert policy.classify("container.exec") == AuthLevel.DUAL_TAP
+        assert policy.classify("container.rm") == AuthLevel.DUAL_TAP
+        assert policy.classify("container.kill") == AuthLevel.DUAL_TAP
+        assert policy.classify("image.rm") == AuthLevel.DUAL_TAP
+        assert policy.classify("volume.rm") == AuthLevel.DUAL_TAP
+        assert policy.classify("system.prune") == AuthLevel.DUAL_TAP
+
+    def test_unknown_operation_defaults_to_single_tap(self):
+        policy = PolicyConfig.load()
+        assert policy.classify("something.unusual") == AuthLevel.SINGLE_TAP
+
+    def test_load_from_yaml(self):
+        yaml_content = """
+policy:
+  auto_approve:
+    - custom.read
+  single_tap:
+    - custom.write
+  dual_tap:
+    - custom.destroy
+"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            f.flush()
+            policy = PolicyConfig.load(Path(f.name))
+
+        assert policy.classify("custom.read") == AuthLevel.AUTO_APPROVE
+        assert policy.classify("custom.write") == AuthLevel.SINGLE_TAP
+        assert policy.classify("custom.destroy") == AuthLevel.DUAL_TAP
+        # Unknown still defaults
+        assert policy.classify("unknown.op") == AuthLevel.SINGLE_TAP
+
+        Path(f.name).unlink()
+
+    def test_load_nonexistent_file_uses_defaults(self):
+        policy = PolicyConfig.load(Path("/nonexistent/policy.yaml"))
+        assert policy.classify("container.logs") == AuthLevel.AUTO_APPROVE
+        assert policy.classify("container.exec") == AuthLevel.DUAL_TAP
+
+
+class TestClassifyDockerCommand:
+    """Integration tests for the full classify pipeline."""
+
+    def test_ps_auto_approved(self):
+        op, level = classify_docker_command(["ps"])
+        assert op == "container.list"
+        assert level == AuthLevel.AUTO_APPROVE
+
+    def test_exec_dual_tap(self):
+        op, level = classify_docker_command(["exec", "container1", "bash"])
+        assert op == "container.exec"
+        assert level == AuthLevel.DUAL_TAP
+
+    def test_compose_up_single_tap(self):
+        op, level = classify_docker_command(["compose", "up", "-d"])
+        assert op == "compose.up"
+        assert level == AuthLevel.SINGLE_TAP
+
+    def test_system_prune_dual_tap(self):
+        op, level = classify_docker_command(["system", "prune"])
+        assert op == "system.prune"
+        assert level == AuthLevel.DUAL_TAP
+
+    def test_logs_auto_approved(self):
+        op, level = classify_docker_command(["logs", "-f", "container1"])
+        assert op == "container.logs"
+        assert level == AuthLevel.AUTO_APPROVE
+
+    def test_restart_single_tap(self):
+        op, level = classify_docker_command(["restart", "container1"])
+        assert op == "container.restart"
+        assert level == AuthLevel.SINGLE_TAP
+
+    def test_with_global_flags(self):
+        op, level = classify_docker_command(["--context", "mainmac", "exec", "c1", "sh"])
+        assert op == "container.exec"
+        assert level == AuthLevel.DUAL_TAP

--- a/tests/test_otp.py
+++ b/tests/test_otp.py
@@ -1,0 +1,318 @@
+"""OTP authentication tests."""
+
+from datetime import datetime, timezone
+
+import pytest
+from starlette.testclient import TestClient
+
+from igris.db.connection import get_connection
+from igris.db.migrations import run_migrations, get_current_version, SCHEMA_VERSION
+from igris.core.otp import (
+    check_rate_limit,
+    hash_password,
+    record_failure,
+    register_otp,
+    verify_otp,
+    verify_password,
+    _failed_attempts,
+)
+from igris.core.session import create_session, validate_session
+from igris.main import app
+
+
+@pytest.fixture(autouse=True)
+def _init_db():
+    """Ensure migrations are applied before each test."""
+    with get_connection() as conn:
+        run_migrations(conn)
+
+
+@pytest.fixture(autouse=True)
+def _clear_rate_limits():
+    """Reset rate limit state between tests."""
+    _failed_attempts.clear()
+    yield
+    _failed_attempts.clear()
+
+
+def _register_test_key(serial: str = "12345678"):
+    """Insert a dummy yubikey for FK constraints."""
+    now = datetime.now(timezone.utc).isoformat()
+    with get_connection() as conn:
+        conn.execute(
+            """INSERT OR IGNORE INTO yubikeys (serial, nickname, public_key, credential_id, registered_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (serial, "test", b"pk", b"cid", now),
+        )
+
+
+# --- Schema migration tests ---
+
+
+def test_migration_v2_creates_otp_table():
+    """Migration v2 should create the otp_credentials table."""
+    with get_connection() as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "otp_credentials" in tables
+
+
+def test_migration_v2_adds_auth_method_column():
+    """Migration v2 should add auth_method column to sessions."""
+    _register_test_key()
+    with get_connection() as conn:
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            """INSERT INTO sessions (session_id, yubikey_serial, created_at, expires_at, ip_address, auth_method)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("sess-test", "12345678", now, now, "127.0.0.1", "otp"),
+        )
+        row = conn.execute(
+            "SELECT auth_method FROM sessions WHERE session_id = 'sess-test'"
+        ).fetchone()
+        assert row["auth_method"] == "otp"
+
+
+def test_migration_v2_schema_version():
+    """Schema version should be 2 after migrations."""
+    assert SCHEMA_VERSION == 2
+    with get_connection() as conn:
+        assert get_current_version(conn) == 2
+
+
+def test_migration_v2_idempotent():
+    """Running migrations twice should not fail."""
+    with get_connection() as conn:
+        run_migrations(conn)
+        run_migrations(conn)
+        assert get_current_version(conn) == 2
+
+
+# --- Password hashing tests ---
+
+
+def test_hash_and_verify_password():
+    pw = "test-password-long-enough"
+    hashed = hash_password(pw)
+    assert hashed != pw
+    assert verify_password(pw, hashed) is True
+
+
+def test_verify_wrong_password():
+    hashed = hash_password("correct-password-here")
+    assert verify_password("wrong-password-here", hashed) is False
+
+
+# --- OTP registration tests ---
+
+
+def test_register_otp_success():
+    _register_test_key()
+    cred_id = register_otp("12345678", "my-secure-otp-password")
+    assert cred_id is not None
+    assert cred_id > 0
+
+
+def test_register_otp_nonexistent_key():
+    with pytest.raises(KeyError, match="not registered"):
+        register_otp("nonexistent", "my-secure-otp-password")
+
+
+def test_register_otp_deactivates_previous():
+    _register_test_key()
+    cred1 = register_otp("12345678", "first-password-here")
+    cred2 = register_otp("12345678", "second-password-here")
+
+    assert cred2 > cred1
+
+    # First credential should be deactivated
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT is_active FROM otp_credentials WHERE id = ?", (cred1,)
+        ).fetchone()
+        assert row["is_active"] == 0
+
+        row = conn.execute(
+            "SELECT is_active FROM otp_credentials WHERE id = ?", (cred2,)
+        ).fetchone()
+        assert row["is_active"] == 1
+
+
+# --- OTP verification tests ---
+
+
+def test_verify_otp_correct_password():
+    _register_test_key()
+    register_otp("12345678", "my-correct-password")
+
+    serial = verify_otp("my-correct-password")
+    assert serial == "12345678"
+
+
+def test_verify_otp_wrong_password():
+    _register_test_key()
+    register_otp("12345678", "my-correct-password")
+
+    serial = verify_otp("wrong-password-here")
+    assert serial is None
+
+
+def test_otp_session_has_otp_auth_method():
+    """OTP sessions should have auth_method='otp'."""
+    _register_test_key()
+    session_id = create_session("12345678", auth_method="otp")
+
+    result = validate_session(session_id)
+    assert result is not None
+    assert result["auth_method"] == "otp"
+
+
+# --- OTP session TTL tests ---
+
+
+def test_otp_session_ttl_shorter_than_fido2(monkeypatch):
+    """OTP sessions should use the shorter OTP TTL."""
+    import igris.config as config_module
+    assert config_module.settings.otp_session_ttl_seconds < config_module.settings.session_ttl_seconds
+
+
+# --- Rate limiting tests ---
+
+
+def test_rate_limit_allows_initial_attempts():
+    assert check_rate_limit("198.51.100.1") is True
+
+
+def test_rate_limit_blocks_after_max_attempts(monkeypatch):
+    import igris.config as config_module
+    monkeypatch.setattr(config_module.settings, "otp_max_attempts", 3)
+
+    for _ in range(3):
+        record_failure("198.51.100.2")
+
+    assert check_rate_limit("198.51.100.2") is False
+
+
+def test_rate_limit_different_ips_independent(monkeypatch):
+    import igris.config as config_module
+    monkeypatch.setattr(config_module.settings, "otp_max_attempts", 2)
+
+    record_failure("198.51.100.3")
+    record_failure("198.51.100.3")
+
+    assert check_rate_limit("198.51.100.3") is False
+    assert check_rate_limit("198.51.100.4") is True
+
+
+# --- API endpoint integration tests ---
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_otp_register_endpoint(client):
+    _register_test_key()
+    resp = client.post(
+        "/auth/otp/register",
+        json={"yubikey_serial": "12345678", "password": "my-long-secure-password"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["yubikey_serial"] == "12345678"
+    assert "credential_id" in data
+
+
+def test_otp_register_short_password(client):
+    _register_test_key()
+    resp = client.post(
+        "/auth/otp/register",
+        json={"yubikey_serial": "12345678", "password": "short"},
+    )
+    assert resp.status_code == 422  # Validation error
+
+
+def test_otp_register_nonexistent_key(client):
+    resp = client.post(
+        "/auth/otp/register",
+        json={"yubikey_serial": "nonexistent", "password": "long-enough-password"},
+    )
+    assert resp.status_code == 404
+
+
+def test_otp_verify_endpoint(client):
+    _register_test_key()
+    # First register
+    client.post(
+        "/auth/otp/register",
+        json={"yubikey_serial": "12345678", "password": "my-long-secure-password"},
+    )
+    # Then verify
+    resp = client.post(
+        "/auth/otp/verify",
+        json={"password": "my-long-secure-password"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["yubikey_serial"] == "12345678"
+    assert data["auth_method"] == "otp"
+    assert "session_id" in data
+
+
+def test_otp_verify_wrong_password(client):
+    _register_test_key()
+    client.post(
+        "/auth/otp/register",
+        json={"yubikey_serial": "12345678", "password": "my-long-secure-password"},
+    )
+    resp = client.post(
+        "/auth/otp/verify",
+        json={"password": "wrong-password-here"},
+    )
+    assert resp.status_code == 401
+
+
+def test_otp_verify_rate_limited(client, monkeypatch):
+    import igris.config as config_module
+    monkeypatch.setattr(config_module.settings, "otp_max_attempts", 2)
+
+    _register_test_key()
+    client.post(
+        "/auth/otp/register",
+        json={"yubikey_serial": "12345678", "password": "my-long-secure-password"},
+    )
+
+    # Exhaust attempts
+    for _ in range(2):
+        client.post("/auth/otp/verify", json={"password": "wrong"})
+
+    # Next attempt should be rate limited
+    resp = client.post("/auth/otp/verify", json={"password": "my-long-secure-password"})
+    assert resp.status_code == 429
+
+
+def test_session_validate_includes_auth_method(client):
+    """Session validate endpoint should return auth_method."""
+    _register_test_key()
+    # Register and verify via OTP
+    client.post(
+        "/auth/otp/register",
+        json={"yubikey_serial": "12345678", "password": "my-long-secure-password"},
+    )
+    resp = client.post(
+        "/auth/otp/verify",
+        json={"password": "my-long-secure-password"},
+    )
+    session_id = resp.json()["session_id"]
+
+    # Validate session
+    resp = client.get(f"/session/validate/{session_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["valid"] is True
+    assert data["auth_method"] == "otp"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -99,3 +99,21 @@ def test_session_creates_audit_entry():
         assert row is not None
         assert row["yubikey_serial"] == "12345678"
         assert row["ip_address"] == "203.0.113.50"
+
+
+def test_create_session_with_auth_method():
+    """create_session should accept and store auth_method."""
+    _register_test_key()
+    session_id = create_session("12345678", auth_method="otp")
+    result = validate_session(session_id)
+    assert result is not None
+    assert result["auth_method"] == "otp"
+
+
+def test_create_session_default_auth_method():
+    """Default auth_method should be 'fido2'."""
+    _register_test_key()
+    session_id = create_session("12345678")
+    result = validate_session(session_id)
+    assert result is not None
+    assert result["auth_method"] == "fido2"

--- a/uv.lock
+++ b/uv.lock
@@ -443,13 +443,15 @@ wheels = [
 
 [[package]]
 name = "igris"
-version = "2.1.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "argon2-cffi" },
     { name = "fastapi" },
     { name = "fido2" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -473,6 +475,8 @@ requires-dist = [
     { name = "fido2", specifier = ">=1.2.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pysqlcipher3", marker = "extra == 'sqlcipher'", specifier = ">=1.2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "typer", specifier = ">=0.15.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
 provides-extras = ["sqlcipher"]
@@ -920,6 +924,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -993,6 +1006,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -31,6 +35,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
 ]
 
 [[package]]
@@ -396,9 +443,10 @@ wheels = [
 
 [[package]]
 name = "igris"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "argon2-cffi" },
     { name = "fastapi" },
     { name = "fido2" },
     { name = "pydantic-settings" },
@@ -420,6 +468,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fido2", specifier = ">=1.2.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },


### PR DESCRIPTION
# igris v3.0.0 — Docker Auth Gating, Slot 1 Migration, Unified CLI

Three-tier YubiKey-gated Docker operations · HMAC-SHA1 Slot 1 migration · Unified Typer CLI

---

## 🎬 Demo

<!-- Drag-and-drop your .mp4 here in the GitHub editor — it'll auto-upload and embed -->
<!-- GitHub renders <video> tags natively for uploaded assets -->


https://github.com/user-attachments/assets/a2415f4f-64a4-41c1-b397-6c11fe1ee7fb



> Full setup → configuration → live YubiKey tap verification in real-time.

---

## Docker Auth Levels

| Level | Operations | Behaviour |
|---|---|---|
| `auto_approve` | `ps`, `logs`, `images`, `inspect`, `info`, `version` | No tap |
| `single_tap` | `start`, `stop`, `restart`, `run`, `build`, `compose up/down` | One YubiKey tap |
| `dual_tap` | `exec`, `rm`, `kill`, `system prune`, `volume rm` | Two taps, 10s window |

---

## ✅ Test Plan

- [x] `uv run pytest` — 86 tests pass
- [x] Setup on main machine: `./scripts/hardware-git-setup.sh setup --docker` — YubiKey tap succeeds
- [x] VM bypass: all Docker commands pass through without verification
- [x] Verify `docker ps` auto-approves, `docker restart <container>` requires single tap, `docker exec <container> bash` requires dual tap

---

<details>
<summary><strong>📋 Full Summary</strong></summary>

- **Docker operation gating** with three-tier policy engine: `auto_approve` (read-only), `single_tap` (state-changing), `dual_tap` (destructive like `exec`, `rm`, `system prune`)
- **YubiKey Slot 1 migration** — all HMAC-SHA1 verification moved from Slot 2 to configurable Slot 1 (Slot 2 reserved for non-igris use, i.e. FIDO2, PIV, OTP)
- **Unified `igris` CLI via Typer**: `igris status`, `igris audit`, `igris policy`
- **timeout fix** for macOS USB HID — `ykman` calls now use `--foreground` to prevent process group isolation breaking device access
- **OTP REST API** endpoints for register/verify (v2 backend)
- **86 tests passing** (26 Docker-specific + 60 existing)

</details>

<details>
<summary><strong>📁 New Files</strong></summary>

- `src/igris/docker/policy.py` — Policy engine (parses Docker CLI → dotted operations → auth level)
- `src/igris/docker/audit.py` — JSONL audit logger (`~/.cache/igris/audit.jsonl`)
- `src/igris/cli.py` — Typer CLI with status/audit/policy/docker subcommands
- `scripts/docker-yubikey-wrapper.sh` — Shell wrapper with fast-path regex for read-only ops
- `tests/test_docker_policy.py`, `tests/test_docker_audit.py` — Unit tests

</details>

<details>
<summary><strong>🏗️ Architecture</strong></summary>

```
docker command
    │
    ▼
docker-yubikey-wrapper.sh
    │
    ├─ fast-path regex (read-only) ──→ auto_approve ──→ passthrough
    │
    └─ python policy engine
         │
         ├─ single_tap ──→ 1x YubiKey HMAC challenge
         │
         └─ dual_tap ──→ 2x YubiKey HMAC challenge (10s window)
         │
         └─ audit.jsonl log
```

</details>
